### PR TITLE
refactor: internal access for unit tests in DEBUG builds

### DIFF
--- a/docs/api/analyzers/diagnostic-codes.md
+++ b/docs/api/analyzers/diagnostic-codes.md
@@ -2,7 +2,7 @@
 
 This page provides a detailed list of diagnostic codes emitted by `Nalix.Analyzers`. These rules help ensure that your application uses the framework correctly and efficiently.
 
-## Usage Codes (NALIX001 - NALIX012, NALIX017 - NALIX019, NALIX047 - NALIX048, NALIX050, NALIX052, NALIX054 - NALIX056, NALIX058)
+## Usage Codes (NALIX001 - NALIX012, NALIX017 - NALIX018, NALIX047 - NALIX048, NALIX050, NALIX052, NALIX054 - NALIX056, NALIX058)
 
 | ID | Title | Severity | Category | Description |
 |---|---|---|---|---|
@@ -18,7 +18,6 @@ This page provides a detailed list of diagnostic codes emitted by `Nalix.Analyze
 | `NALIX012` | PacketBase packet should expose static Deserialize | Warning | Usage | Nalix packet types built on PacketBase<TSelf> should have an accessible static Deserialize(ReadOnlySpan<byte>) entry point, declared on the type or inherited from PacketBase hierarchy. |
 | `NALIX017` | Packet Deserialize signature is invalid | Warning | Usage | Nalix packet types should expose a public static Deserialize(ReadOnlySpan<byte>) helper with the packet type as return value. |
 | `NALIX018` | Registered packet type must be concrete | Warning | Usage | Nalix packet registry should register only concrete, non-abstract, non-generic packet types. |
-| `` | | | | |
 | `NALIX047` | Dispatch loop count is out of supported range | Warning | Usage | `WithDispatchLoopCount` expects a value in the range `1..64`. |
 | `NALIX048` | Packet controller handler return type is unsupported | Warning | Usage | Handler return type is not supported by Nalix return handlers. |
 | `NALIX050` | PacketOpcode is declared on a non-controller type | Info | Usage | `[PacketOpcode]` is expected on methods inside `[PacketController]` types. |
@@ -42,16 +41,14 @@ This page provides a detailed list of diagnostic codes emitted by `Nalix.Analyze
 | `NALIX046` | `SerializeOrder` gap is unusually large | Info | Serialization | `SerializeOrder` is ordering metadata, not a byte offset. Large jumps are allowed but may indicate accidental numbering. |
 | `NALIX051` | `IFixedSizeSerializable` type contains dynamic serialization member | Warning | Serialization | Fixed-size serializable types should avoid variable-size members such as `string`, arrays, or nested packets. |
 
-## Middleware and Routing Codes (NALIX006 - NALIX007, NALIX025 - NALIX026, NALIX030 - NALIX033)
+## Middleware and Routing Codes (NALIX006, NALIX025 - NALIX026, NALIX030, NALIX032 - NALIX033, NALIX035 - NALIX036, NALIX038)
 
 | ID | Title | Severity | Category | Description |
 |---|---|---|---|---|
 | `NALIX006` | Registered middleware type does not match dispatcher packet type | Warning | Usage | Nalix packet middleware should be registered against a compatible PacketDispatchOptions<TPacket>. |
-| `` | | | | |
 | `NALIX025` | Packet metadata provider clears Opcode | Warning | Routing | Nalix packet metadata providers should not clear builder.Opcode because packet metadata requires a non-null opcode. |
 | `NALIX026` | Packet metadata provider overwrites Opcode without guard | Info | Routing | Nalix packet metadata providers usually should augment metadata instead of unconditionally replacing an existing PacketOpcodeAttribute. |
 | `NALIX030` | Packet middleware should declare MiddlewareOrder | Info | Middleware | Nalix packet middleware ordering is more predictable when each middleware declares MiddlewareOrderAttribute explicitly. |
-| `` | | | | |
 | `NALIX032` | Inbound middleware ignores AlwaysExecute | Info | Middleware | Nalix AlwaysExecute only changes outbound middleware behavior. It has no effect on inbound-only middleware. |
 | `NALIX033` | Registered middleware shares `MiddlewareOrder` with another | Info | Middleware | Nalix middleware registration chains are easier to reason about when `MiddlewareOrder` values are unique within the same builder chain. |
 | `NALIX035` | `PacketOpcode` is in reserved range | Warning | Routing | OpCodes between `0x0000` and `0x00FF` are reserved for internal Nalix system packets. |

--- a/src/Nalix.Analyzers/Analyzers/NalixUsageAnalyzer.InvocationAnalysis.cs
+++ b/src/Nalix.Analyzers/Analyzers/NalixUsageAnalyzer.InvocationAnalysis.cs
@@ -61,12 +61,7 @@ public sealed partial class NalixUsageAnalyzer
         else if (methodName == "WithMiddleware")
         {
             AnalyzeWithMiddlewareInvocation(context, invocation, symbols);
-            AnalyzeMiddlewareRegistrationDuplicateOrder(context, invocation, symbols, bufferMiddleware: false);
-        }
-        else if (methodName == "WithBufferMiddleware")
-        {
-            AnalyzeWithBufferMiddlewareInvocation(context, invocation, symbols);
-            AnalyzeMiddlewareRegistrationDuplicateOrder(context, invocation, symbols, bufferMiddleware: true);
+            AnalyzeMiddlewareRegistrationDuplicateOrder(context, invocation, symbols);
         }
         else if (methodName == "RegisterPacket")
         {
@@ -81,8 +76,7 @@ public sealed partial class NalixUsageAnalyzer
     private static void AnalyzeMiddlewareRegistrationDuplicateOrder(
         OperationAnalysisContext context,
         IInvocationOperation invocation,
-        SymbolSet symbols,
-        bool bufferMiddleware)
+        SymbolSet symbols)
     {
         if (invocation.Arguments.Length != 1)
         {
@@ -95,7 +89,7 @@ public sealed partial class NalixUsageAnalyzer
             return;
         }
 
-        string expectedMethodName = bufferMiddleware ? "WithBufferMiddleware" : "WithMiddleware";
+        string expectedMethodName = "WithMiddleware";
         if (previousInvocation.TargetMethod.Name != expectedMethodName
             || previousInvocation.Arguments.Length != 1)
         {
@@ -586,31 +580,4 @@ public sealed partial class NalixUsageAnalyzer
         }
     }
 
-    private static void AnalyzeWithBufferMiddlewareInvocation(OperationAnalysisContext context, IInvocationOperation invocation, SymbolSet symbols)
-    {
-        IArgumentOperation? middlewareArgument = invocation.Arguments.FirstOrDefault();
-        if (middlewareArgument is not null && IsNullLiteral(middlewareArgument.Value))
-        {
-            Report(context, DiagnosticDescriptors.MiddlewareRegistrationNullLiteral, invocation.Syntax.GetLocation(), invocation.TargetMethod.Name);
-            return;
-        }
-
-        IOperation? valueOperation = middlewareArgument?.Value;
-        ITypeSymbol? middlewareType = valueOperation is IConversionOperation conversion
-            ? conversion.Operand.Type
-            : valueOperation?.Type;
-        if (middlewareType is null)
-        {
-            return;
-        }
-
-        if (Implements(middlewareType, symbols.NetworkBufferMiddlewareType) && HasAttribute(middlewareType, symbols.MiddlewareStageAttribute))
-        {
-            Report(context, DiagnosticDescriptors.BufferMiddlewareShouldNotUseStageAttribute, invocation.Syntax.GetLocation(), middlewareType.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat));
-        }
-        else if (!Implements(middlewareType, symbols.NetworkBufferMiddlewareType))
-        {
-            Report(context, DiagnosticDescriptors.BufferMiddlewareRegistrationTypeMismatch, invocation.Syntax.GetLocation(), middlewareType.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat));
-        }
-    }
 }

--- a/src/Nalix.Analyzers/Analyzers/NalixUsageAnalyzer.SymbolSet.cs
+++ b/src/Nalix.Analyzers/Analyzers/NalixUsageAnalyzer.SymbolSet.cs
@@ -164,7 +164,6 @@ public sealed partial class NalixUsageAnalyzer
             INamedTypeSymbol? packetRegistryFactoryType = compilation.GetTypeByMetadataName("Nalix.Framework.DataFrames.PacketRegistryFactory");
             INamedTypeSymbol? packetDeserializerType = compilation.GetTypeByMetadataName("Nalix.Common.Networking.Packets.IPacketDeserializer`1");
             INamedTypeSymbol? packetMiddlewareType = compilation.GetTypeByMetadataName("Nalix.Runtime.Middleware.IPacketMiddleware`1");
-            INamedTypeSymbol? networkBufferMiddlewareType = compilation.GetTypeByMetadataName("Nalix.Runtime.Middleware.INetworkBufferMiddleware");
             INamedTypeSymbol? networkApplicationBuilderType = compilation.GetTypeByMetadataName("Nalix.Network.Hosting.NetworkApplicationBuilder");
             INamedTypeSymbol? middlewareOrderAttribute = compilation.GetTypeByMetadataName("Nalix.Common.Middleware.MiddlewareOrderAttribute");
             INamedTypeSymbol? middlewareStageAttribute = compilation.GetTypeByMetadataName("Nalix.Common.Middleware.MiddlewareStageAttribute");
@@ -225,7 +224,7 @@ public sealed partial class NalixUsageAnalyzer
                     packetRegistryFactoryType,
                     packetDeserializerType,
                     packetMiddlewareType,
-                    networkBufferMiddlewareType,
+                    null, // networkBufferMiddlewareType removed
                     networkApplicationBuilderType,
                     middlewareOrderAttribute,
                     middlewareStageAttribute,

--- a/src/Nalix.Analyzers/Analyzers/NalixUsageAnalyzer.cs
+++ b/src/Nalix.Analyzers/Analyzers/NalixUsageAnalyzer.cs
@@ -132,27 +132,15 @@ public sealed partial class NalixUsageAnalyzer : DiagnosticAnalyzer
             return;
         }
 
-        if (HasAttribute(typeSymbol, symbols.ControllerAttribute))
-        {
-            AnalyzeControllerType(context, typeSymbol, symbols, globalOpcodes, controllerNames);
-        }
-
         AnalyzePacketType(context, typeSymbol, symbols);
         AnalyzeSerializationType(context, typeSymbol, symbols);
         AnalyzeConfigurationType(context, typeSymbol, symbols);
         AnalyzeMetadataProviderType(context, typeSymbol, symbols);
         AnalyzeMiddlewareType(context, typeSymbol, symbols);
-
-        if (Implements(typeSymbol, symbols.NetworkBufferMiddlewareType) && HasAttribute(typeSymbol, symbols.MiddlewareStageAttribute))
+ 
+        if (HasAttribute(typeSymbol, symbols.ControllerAttribute))
         {
-            Location? location = typeSymbol.Locations.FirstOrDefault(static l => l.IsInSource);
-            if (location is not null)
-            {
-                context.ReportDiagnostic(Diagnostic.Create(
-                    DiagnosticDescriptors.BufferMiddlewareShouldNotUseStageAttribute,
-                    location,
-                    typeSymbol.Name));
-            }
+            AnalyzeControllerType(context, typeSymbol, symbols, globalOpcodes, controllerNames);
         }
     }
 
@@ -242,10 +230,7 @@ public sealed partial class NalixUsageAnalyzer : DiagnosticAnalyzer
 
     private static void AnalyzeMiddlewareType(SymbolAnalysisContext context, INamedTypeSymbol typeSymbol, SymbolSet symbols)
     {
-        bool isPacketMiddleware = ImplementsOpenGeneric(typeSymbol, symbols.PacketMiddlewareType);
-        bool isBufferMiddleware = Implements(typeSymbol, symbols.NetworkBufferMiddlewareType);
-
-        if (!isPacketMiddleware && !isBufferMiddleware)
+        if (!ImplementsOpenGeneric(typeSymbol, symbols.PacketMiddlewareType))
         {
             return;
         }
@@ -255,22 +240,9 @@ public sealed partial class NalixUsageAnalyzer : DiagnosticAnalyzer
         AttributeData? stageAttribute = typeSymbol.GetAttributes()
             .FirstOrDefault(a => SymbolEqualityComparer.Default.Equals(a.AttributeClass, symbols.MiddlewareStageAttribute));
 
-        if (isPacketMiddleware && orderAttribute is null)
+        if (orderAttribute is null)
         {
             Report(context, DiagnosticDescriptors.PacketMiddlewareMissingOrder, typeSymbol, typeSymbol.Name);
-        }
-
-        if (isBufferMiddleware)
-        {
-            if (orderAttribute is null)
-            {
-                Report(context, DiagnosticDescriptors.BufferMiddlewareMissingOrder, typeSymbol, typeSymbol.Name);
-            }
-
-            if (stageAttribute is not null)
-            {
-                return;
-            }
         }
 
         if (stageAttribute is not null && IsInboundAlwaysExecute(stageAttribute, symbols.MiddlewareStageType))
@@ -1009,7 +981,13 @@ public sealed partial class NalixUsageAnalyzer : DiagnosticAnalyzer
             return null;
         }
 
-        return attribute.ConstructorArguments[0].Value is ushort opcode ? opcode : null;
+        object? value = attribute.ConstructorArguments[0].Value;
+        return value switch
+        {
+            ushort u => u,
+            int i => (ushort)i,
+            _ => null
+        };
     }
 
     private static bool HasAttribute(ISymbol symbol, INamedTypeSymbol? attributeSymbol)
@@ -1451,7 +1429,7 @@ public sealed partial class NalixUsageAnalyzer : DiagnosticAnalyzer
             return true;
         }
 
-        if (method.Name == "InvokeAsync" && (ImplementsOpenGeneric(method.ContainingType, symbols.PacketMiddlewareType) || Implements(method.ContainingType, symbols.NetworkBufferMiddlewareType)))
+        if (method.Name == "InvokeAsync" && ImplementsOpenGeneric(method.ContainingType, symbols.PacketMiddlewareType))
         {
             return true;
         }

--- a/src/Nalix.SDK/Transport/Internal/PacketAwaiter.cs
+++ b/src/Nalix.SDK/Transport/Internal/PacketAwaiter.cs
@@ -8,7 +8,9 @@ using System.Threading.Tasks;
 using Nalix.Common.Networking.Packets;
 using Nalix.SDK.Transport.Extensions;
 
+#if DEBUG
 [assembly: InternalsVisibleTo("Nalix.SDK.Tests")]
+#endif
 
 namespace Nalix.SDK.Transport.Internal;
 

--- a/tests/Nalix.Analyzers.Tests/AdvancedPacketAnalyzerTests.cs
+++ b/tests/Nalix.Analyzers.Tests/AdvancedPacketAnalyzerTests.cs
@@ -34,34 +34,4 @@ public sealed class Example
             "NALIX018");
     }
 
-    [Fact]
-    public async Task WithBufferMiddlewareTypeMismatch_ProducesDiagnostic()
-    {
-        const string source = """
-namespace Demo;
-using Nalix.Common.Networking.Packets;
-using Nalix.Runtime.Dispatching;
-
-public sealed class SomePacket : Nalix.Framework.DataFrames.PacketBase<SomePacket>
-{
-    public static new SomePacket Deserialize(ReadOnlySpan<byte> buffer) => PacketBase<SomePacket>.Deserialize(buffer);
-}
-
-public sealed class NotBufferMiddleware
-{
-}
-
-public sealed class Example
-{
-    public void Run()
-    {
-        new PacketDispatchOptions<SomePacket>().WithBufferMiddleware((Nalix.Runtime.Middleware.INetworkBufferMiddleware)(object)new NotBufferMiddleware());
-    }
-}
-""";
-
-        await Verifier<CodeFixes.PacketRegistryDeserializerCodeFixProvider>.VerifyAnalyzerAsync(
-            source,
-            "NALIX019");
-    }
 }

--- a/tests/Nalix.Analyzers.Tests/CustomControllerAnalyzerTests.cs
+++ b/tests/Nalix.Analyzers.Tests/CustomControllerAnalyzerTests.cs
@@ -149,29 +149,4 @@ public sealed class LoginPacket : Nalix.Framework.DataFrames.PacketBase<LoginPac
             "NALIX038");
     }
 
-    [Fact]
-    public async Task BufferLeaseLeak_ProducesDiagnostic()
-    {
-        const string source = """
-namespace Demo;
-using Nalix.Common.Abstractions;
-using Nalix.Runtime.Middleware;
-using Nalix.Common.Networking;
-
-public sealed class LeakMiddleware : INetworkBufferMiddleware
-{
-    public ValueTask<IBufferLease?> InvokeAsync(IBufferLease buffer, IConnection connection, Func<IBufferLease, CancellationToken, ValueTask<IBufferLease?>> next, CancellationToken ct)
-    {
-        // Leak: buffer is not disposed and not passed to next
-        return ValueTask.FromResult<IBufferLease?>(null);
-    }
-}
-""";
-
-        await Verifier<CodeFixes.PacketOpcodeCodeFixProvider>.VerifyAnalyzerAsync(
-            source,
-            "NALIX031", // Missing MiddlewareOrder
-            "NALIX039"  // Leak
-        );
-    }
 }

--- a/tests/Nalix.Analyzers.Tests/NalixUsageAnalyzerTests.cs
+++ b/tests/Nalix.Analyzers.Tests/NalixUsageAnalyzerTests.cs
@@ -482,27 +482,6 @@ public sealed class DemoPacketMiddleware : IPacketMiddleware<DemoPacket>
         await AnalyzerTestHarness.AssertDiagnosticIdsAsync(source, "NALIX030");
     }
 
-    [Fact]
-    public async Task BufferMiddlewareMissingOrder_ReportsNalix031()
-    {
-        const string source = """
-namespace Demo;
-using Nalix.Common.Abstractions;
-using Nalix.Common.Networking;
-using Nalix.Runtime.Middleware;
-
-public sealed class DemoBufferMiddleware : INetworkBufferMiddleware
-{
-    public ValueTask<IBufferLease?> InvokeAsync(
-        IBufferLease buffer,
-        IConnection connection,
-        Func<IBufferLease, CancellationToken, ValueTask<IBufferLease?>> nextHandler,
-        CancellationToken ct) => nextHandler(buffer, ct);
-}
-""";
-
-        await AnalyzerTestHarness.AssertDiagnosticIdsAsync(source, "NALIX031");
-    }
 
     [Fact]
     public async Task ControllerWithDuplicateOpcodes_ReportsNalix001()
@@ -618,31 +597,6 @@ public static class Setup
 """;
 
         await AnalyzerTestHarness.AssertDiagnosticIdsAsync(source, "NALIX006");
-    }
-
-    [Fact]
-    public async Task BufferMiddlewareWithStageAttribute_ReportsNalix007()
-    {
-        const string source = """
-namespace Demo;
-using Nalix.Common.Abstractions;
-using Nalix.Common.Middleware;
-using Nalix.Common.Networking;
-using Nalix.Runtime.Middleware;
-
-[MiddlewareOrder(1)]
-[MiddlewareStage(MiddlewareStage.Inbound)]
-public sealed class DemoBufferMiddleware : INetworkBufferMiddleware
-{
-    public ValueTask<IBufferLease?> InvokeAsync(
-        IBufferLease buffer,
-        IConnection connection,
-        Func<IBufferLease, CancellationToken, ValueTask<IBufferLease?>> nextHandler,
-        CancellationToken ct) => nextHandler(buffer, ct);
-}
-""";
-
-        await AnalyzerTestHarness.AssertDiagnosticIdsAsync(source, "NALIX007");
     }
 
     [Fact]
@@ -1271,37 +1225,6 @@ public static class Setup
         await AnalyzerTestHarness.AssertDiagnosticIdsAsync(source, "NALIX005");
     }
 
-    [Fact]
-    public async Task WithBufferMiddlewareTypeMismatch_ReportsNalix019()
-    {
-        const string source = """
-namespace Demo;
-using Nalix.Runtime.Dispatching;
-using Nalix.Runtime.Middleware;
-using Nalix.Common.Networking.Packets;
-using Nalix.Framework.DataFrames;
-
-public sealed class DemoPacket : PacketBase<DemoPacket>
-{
-    public static new DemoPacket Deserialize(ReadOnlySpan<byte> buffer) => PacketBase<DemoPacket>.Deserialize(buffer);
-}
-
-public sealed class NotABufferMiddleware
-{
-}
-
-public static class Setup
-{
-    public static void Configure()
-    {
-        _ = new PacketDispatchOptions<DemoPacket>()
-            .WithBufferMiddleware((INetworkBufferMiddleware)(object)new NotABufferMiddleware());
-    }
-}
-""";
-
-        await AnalyzerTestHarness.AssertDiagnosticIdsAsync(source, "NALIX019");
-    }
 
     [Fact]
     public async Task NetworkBuildWithoutRecommendedSetup_ReportsNalix040_041_044()

--- a/tests/Nalix.Analyzers.Tests/TestSources.cs
+++ b/tests/Nalix.Analyzers.Tests/TestSources.cs
@@ -78,7 +78,6 @@ namespace Nalix.Runtime.Dispatching
     {
         public PacketDispatchOptions<TPacket> WithHandler<TController>() where TController : class => this;
         public PacketDispatchOptions<TPacket> WithMiddleware(IPacketMiddleware<TPacket> middleware) => this;
-        public PacketDispatchOptions<TPacket> WithBufferMiddleware(INetworkBufferMiddleware middleware) => this;
         public PacketDispatchOptions<TPacket> WithDispatchLoopCount(int count) => this;
     }
 
@@ -107,10 +106,6 @@ namespace Nalix.Runtime.Middleware
         ValueTask InvokeAsync(IPacketContext<TPacket> context, Func<CancellationToken, ValueTask> next);
     }
 
-    public interface INetworkBufferMiddleware
-    {
-        ValueTask<IBufferLease?> InvokeAsync(IBufferLease buffer, IConnection connection, Func<IBufferLease, CancellationToken, ValueTask<IBufferLease?>> nextHandler, CancellationToken ct);
-    }
 }
 
 namespace Nalix.Common.Networking.Packets

--- a/tests/Nalix.Analyzers.Tests/Verifier.cs
+++ b/tests/Nalix.Analyzers.Tests/Verifier.cs
@@ -174,7 +174,6 @@ internal static class Verifier<TCodeFix>
             "Nalix.Framework.DataFrames.PacketRegistryFactory",
             "Nalix.Common.Networking.Packets.IPacketDeserializer`1",
             "Nalix.Runtime.Middleware.IPacketMiddleware`1",
-            "Nalix.Runtime.Middleware.INetworkBufferMiddleware",
             "Nalix.Common.Serialization.SerializeOrderAttribute",
             "Nalix.Common.Middleware.MiddlewareOrderAttribute",
             "Nalix.Common.Middleware.MiddlewareStageAttribute",

--- a/tests/Nalix.SDK.Tests/PacketAwaiterTests.cs
+++ b/tests/Nalix.SDK.Tests/PacketAwaiterTests.cs
@@ -1,3 +1,4 @@
+#if DEBUG
 using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Threading;
@@ -328,3 +329,4 @@ public sealed class PacketAwaiterTests
         }
     }
 }
+#endif


### PR DESCRIPTION
Added InternalsVisibleTo("Nalix.SDK.Tests") attribute, conditionally compiled for DEBUG builds, to allow unit tests to access internal members without exposing them in release builds. This improves testability while maintaining encapsulation in production.

## Summary

<!-- Briefly describe the purpose of this PR and what it implements or fixes. -->

Closes #<!-- issue number -->

---

## Type of Change

- [x] 🐛 Bug fix
- [ ] 🚀 Feature / enhancement
- [ ] ⚡ Performance improvement
- [ ] 🔧 Refactor
- [ ] 📚 Documentation update
- [ ] 🔒 Security fix
- [ ] 🧪 Tests

---

## How to Test

<!-- Describe steps to verify this PR. -->

1.
2.
3.

---

## Screenshots (if applicable)

<!-- Add screenshots or videos for UI changes. Remove this section if not applicable. -->

---

## Additional Notes

<!-- Optional: breaking changes, dependencies, deployment notes, anything reviewers should know. -->

---

## Checklist

- [ ] Code follows project style guidelines (`.editorconfig`).
- [ ] Tests cover all changes.
- [ ] All tests pass locally (`dotnet test`).
- [ ] Documentation updated (if applicable).
- [ ] Self-reviewed my own code.
- [ ] No merge conflicts with `master`.
