### PR TITLE
feature: configure certificate

### DIFF
--- a/docs/api/hosting/network-application.md
+++ b/docs/api/hosting/network-application.md
@@ -51,7 +51,7 @@ graph LR
 | Type | Public members |
 |---|---|
 | `NetworkApplication` | `CreateBuilder()`, `ActivateAsync(...)`, `DeactivateAsync(...)`, `RunAsync(...)`, `Dispose()` |
-| `INetworkApplicationBuilder` | `ConfigureLogging(...)`, `ConfigureConnectionHub(...)`, `ConfigureBufferPoolManager(...)`, `Configure<TOptions>(...)`, `AddPacket(...)`, `AddHandlers(...)`, `AddHandler(...)`, `AddMetadataProvider(...)`, `ConfigureDispatch(...)`, `AddTcp(...)`, `AddUdp(...)`, `Build()` |
+| `INetworkApplicationBuilder` | `ConfigureLogging(...)`, `ConfigureConnectionHub(...)`, `ConfigureBufferPoolManager(...)`, `ConfigureCertificate(...)`, `Configure<TOptions>(...)`, `AddPacket(...)`, `AddHandlers(...)`, `AddHandler(...)`, `AddMetadataProvider(...)`, `ConfigureDispatch(...)`, `AddTcp(...)`, `AddUdp(...)`, `Build()` |
 
 ## `NetworkApplication`
 
@@ -76,6 +76,7 @@ The builder uses a fluent API to configure the host before it is built.
 - `ConfigureLogging(ILogger)`: Registers the logger into the `InstanceManager`.
 - `ConfigureConnectionHub(IConnectionHub)`: Registers the shared connection hub into the `InstanceManager`.
 - `ConfigureBufferPoolManager(BufferPoolManager)`: Explicitly registers a custom buffer pool manager and binds `BufferLease.ByteArrayPool` to that manager for pooled receive/send paths.
+- `ConfigureCertificate(string path)`: Configures the absolute path to the server identity certificate (`certificate.private`).
 - `Configure<TOptions>(Action<TOptions>)`: Configures a specific options type. This is applied during the activation phase.
 
 !!! note

--- a/docs/concepts/application/hosting-model.md
+++ b/docs/concepts/application/hosting-model.md
@@ -21,9 +21,10 @@ var builder = NetworkApplication.CreateBuilder(args);
 InstanceManager.Instance.Register<IDatabase>(new MyMongoDatabase());
 
 // 2. Configure Listeners
-builder.AddTcpListener(options => {
-    options.Port = 8080;
-});
+builder.ConfigureCertificate("path/to/certificate.private")
+       .AddTcpListener(options => {
+           options.Port = 8080;
+       });
 
 var app = builder.Build();
 

--- a/docs/concepts/security/handshake-protocol.md
+++ b/docs/concepts/security/handshake-protocol.md
@@ -8,7 +8,9 @@ Nalix implements a high-security, zero-trust handshake protocol based on **X2551
 - [x] **Identity Verification**: Requires pinned server public keys to prevent Man-in-the-Middle (MitM) attacks. Anonymous handshakes are strictly forbidden; both the client and server must load valid identities from standardized storage.
 
 !!! critical "Mandatory Identity"
-    Every Nalix server must possess a `certificate.private` file. Clients must be configured with the server's `certificate.public` hash (or the full key) during the connection setup to enable public key pinning.
+    Every Nalix server must possess a `certificate.private` file. By default, the server looks for this file in the standardized configuration directory. You can override this path using `builder.ConfigureCertificate("path/to/identity")` during host construction.
+    
+    Clients must be configured with the server's `certificate.public` hash (or the full key) during the connection setup to enable public key pinning.
 
 - [x] **Transcript Integrity**: All handshake messages are hashed into a transcript to prevent tampering or replay attacks.
 

--- a/src/Nalix.Network.Hosting/INetworkApplicationBuilder.cs
+++ b/src/Nalix.Network.Hosting/INetworkApplicationBuilder.cs
@@ -47,6 +47,13 @@ public interface INetworkApplicationBuilder
     INetworkApplicationBuilder ConfigureBufferPoolManager(BufferPoolManager manager);
 
     /// <summary>
+    /// Configures the server identity certificate path.
+    /// </summary>
+    /// <param name="certificatePath">The absolute path to the certificate file.</param>
+    /// <returns>The current builder instance.</returns>
+    INetworkApplicationBuilder ConfigureCertificate(string certificatePath);
+
+    /// <summary>
     /// Configures a Nalix options object before the host starts.
     /// </summary>
     /// <typeparam name="TOptions">The configuration type to mutate.</typeparam>

--- a/src/Nalix.Network.Hosting/Internal/HostingBuilderContext.cs
+++ b/src/Nalix.Network.Hosting/Internal/HostingBuilderContext.cs
@@ -77,6 +77,11 @@ internal sealed class HostingBuilderContext
     /// Defaults to <see cref="NullLogger.Instance"/> when no logger is provided.
     /// </value>
     public ILogger Logger { get; set; } = NullLogger.Instance;
+
+    /// <summary>
+    /// Gets or sets the optional path to the server identity certificate.
+    /// </summary>
+    public string? IdentityCertificatePath { get; set; }
 }
 
 /// <summary>

--- a/src/Nalix.Network.Hosting/NetworkApplicationBuilder.cs
+++ b/src/Nalix.Network.Hosting/NetworkApplicationBuilder.cs
@@ -316,6 +316,14 @@ public sealed class NetworkApplicationBuilder : INetworkApplicationBuilder
     }
 
     /// <inheritdoc />
+    public INetworkApplicationBuilder ConfigureCertificate(string certificatePath)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(certificatePath);
+        _state.IdentityCertificatePath = certificatePath;
+        return this;
+    }
+
+    /// <inheritdoc />
     public NetworkApplication Build()
     {
         bool metadataRegistered = false;
@@ -327,6 +335,15 @@ public sealed class NetworkApplicationBuilder : INetworkApplicationBuilder
 
             this.EnsureConnectionHubRegistered();
             this.EnsureBufferPoolManagerRegistered();
+
+            if (_state.IdentityCertificatePath is not null)
+            {
+                HandshakeHandlers.SetCertificatePath(_state.IdentityCertificatePath);
+            }
+            else
+            {
+                HandshakeHandlers.Initialize();
+            }
 
             if (!metadataRegistered)
             {

--- a/src/Nalix.Runtime/Handlers/HandshakeHandlers.cs
+++ b/src/Nalix.Runtime/Handlers/HandshakeHandlers.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
 using Nalix.Common.Abstractions;
 using Nalix.Common.Exceptions;
@@ -30,19 +31,127 @@ namespace Nalix.Runtime.Handlers;
 [PacketController("Handshake")]
 public sealed class HandshakeHandlers
 {
+    #region Fields
+
     private static IConnectionHub? Hub => InstanceManager.Instance.GetExistingInstance<IConnectionHub>();
 
-    private static readonly Bytes32 s_certificate = Bytes32.Zero;
+    private static Bytes32 s_certificate = Bytes32.Zero;
+    private static bool s_isInitialized;
+    private static readonly Lock s_initLock = new();
 
-    /// <inheritdoc/>
-    static HandshakeHandlers()
+    #endregion Fields
+
+    #region APIs
+
+    /// <summary>
+    /// Initializes the handshake handlers with the default certificate.
+    /// </summary>
+    /// <remarks>
+    /// This is called automatically by the host builder if no custom certificate path is specified.
+    /// </remarks>
+    public static void Initialize()
     {
-        string certPath = Path.Combine(Directories.ConfigurationDirectory, "certificate.private");
+        if (s_isInitialized)
+        {
+            return;
+        }
 
+        lock (s_initLock)
+        {
+            if (s_isInitialized)
+            {
+                return;
+            }
+
+            LOAD_CERTIFICATE(Path.Combine(Directories.ConfigurationDirectory, "certificate.private"));
+            s_isInitialized = true;
+        }
+    }
+
+    /// <summary>
+    /// Sets a custom path for the server identity certificate and initializes it.
+    /// </summary>
+    /// <param name="path">The absolute path to the certificate file.</param>
+    public static void SetCertificatePath(string path)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(path);
+        lock (s_initLock)
+        {
+            LOAD_CERTIFICATE(path);
+            s_isInitialized = true;
+        }
+    }
+
+    /// <summary>
+    /// Handles incoming handshake signal packets.
+    /// </summary>
+    /// <param name="context">The packet context containing the handshake metadata.</param>
+    /// <returns>A responding handshake packet or null if rejected/disconnected.</returns>
+    [ReservedOpcodePermitted]
+    [PacketEncryption(false)]
+    [PacketPermission(PermissionLevel.NONE)]
+    [PacketOpcode((ushort)ProtocolOpCode.HANDSHAKE)]
+    public static async ValueTask HandleAsync(IPacketContext<Handshake> context)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+
+        Handshake packet = context.Packet;
+        IConnection connection = context.Connection;
+
+        if (connection.Attributes.ContainsKey(ConnectionAttributes.HandshakeEstablished))
+        {
+            await RejectHandshakeAsync(connection, ProtocolReason.STATE_VIOLATION).ConfigureAwait(false);
+            return;
+        }
+
+        switch (packet.Stage)
+        {
+            case HandshakeStage.CLIENT_HELLO:
+                await HandleClientHelloAsync(connection, packet).ConfigureAwait(false);
+                break;
+
+            case HandshakeStage.CLIENT_FINISH:
+                await HandleClientFinishAsync(connection, packet).ConfigureAwait(false);
+                break;
+
+            case HandshakeStage.ERROR:
+                connection.Disconnect("Handshake error received from peer.");
+                break;
+
+            case HandshakeStage.NONE:
+            case HandshakeStage.SERVER_HELLO:
+            case HandshakeStage.SERVER_FINISH:
+            default:
+                await RejectHandshakeAsync(connection, ProtocolReason.UNEXPECTED_MESSAGE).ConfigureAwait(false);
+                break;
+        }
+    }
+
+    #endregion APIs
+
+    #region Private Methods
+
+    #region Nested Types
+
+    private sealed record HandshakeContext
+    {
+        public Bytes32 ClientPublicKey { get; init; }
+        public Bytes32 ClientNonce { get; init; }
+        public Bytes32 ServerPublicKey { get; init; }
+        public Bytes32 ServerNonce { get; init; }
+        public Bytes32 SharedSecret { get; init; }
+        public Bytes32 TranscriptHash { get; init; }
+        public Bytes32 SessionKey { get; init; }
+    }
+
+    #endregion Nested Types
+
+    private static void LOAD_CERTIFICATE(string certPath)
+    {
         if (!File.Exists(certPath))
         {
             throw new InternalErrorException(
-                $"Handshake failed: certificate file 'certificate.private' was not found in '{Directories.ConfigurationDirectory}'. "
+                $"Handshake failed: certificate file was not found at '{certPath}'. "
                 + "Please provide a valid server identity file.");
         }
 
@@ -93,53 +202,6 @@ public sealed class HandshakeHandlers
                 $"Handshake failed: Invalid server identity format in '{certPath}'. Exception detail: " + ex.Message, ex);
         }
     }
-
-    /// <summary>
-    /// Handles incoming handshake signal packets.
-    /// </summary>
-    /// <param name="context">The packet context containing the handshake metadata.</param>
-    /// <returns>A responding handshake packet or null if rejected/disconnected.</returns>
-    [ReservedOpcodePermitted]
-    [PacketEncryption(false)]
-    [PacketPermission(PermissionLevel.NONE)]
-    [PacketOpcode((ushort)ProtocolOpCode.HANDSHAKE)]
-    public static async ValueTask HandleAsync(IPacketContext<Handshake> context)
-    {
-        ArgumentNullException.ThrowIfNull(context);
-
-        Handshake packet = context.Packet;
-        IConnection connection = context.Connection;
-
-        if (connection.Attributes.ContainsKey(ConnectionAttributes.HandshakeEstablished))
-        {
-            await RejectHandshakeAsync(connection, ProtocolReason.STATE_VIOLATION).ConfigureAwait(false);
-            return;
-        }
-
-        switch (packet.Stage)
-        {
-            case HandshakeStage.CLIENT_HELLO:
-                await HandleClientHelloAsync(connection, packet).ConfigureAwait(false);
-                break;
-
-            case HandshakeStage.CLIENT_FINISH:
-                await HandleClientFinishAsync(connection, packet).ConfigureAwait(false);
-                break;
-
-            case HandshakeStage.ERROR:
-                connection.Disconnect("Handshake error received from peer.");
-                break;
-
-            case HandshakeStage.NONE:
-            case HandshakeStage.SERVER_HELLO:
-            case HandshakeStage.SERVER_FINISH:
-            default:
-                await RejectHandshakeAsync(connection, ProtocolReason.UNEXPECTED_MESSAGE).ConfigureAwait(false);
-                break;
-        }
-    }
-
-    #region Private Methods
 
     private static async ValueTask HandleClientHelloAsync(IConnection connection, Handshake packet)
     {
@@ -281,17 +343,6 @@ public sealed class HandshakeHandlers
 
         state = null;
         return false;
-    }
-
-    private sealed record HandshakeContext
-    {
-        public Bytes32 ClientPublicKey { get; init; }
-        public Bytes32 ClientNonce { get; init; }
-        public Bytes32 ServerPublicKey { get; init; }
-        public Bytes32 ServerNonce { get; init; }
-        public Bytes32 SharedSecret { get; init; }
-        public Bytes32 TranscriptHash { get; init; }
-        public Bytes32 SessionKey { get; init; }
     }
 
     #endregion Private Methods


### PR DESCRIPTION
This pull request introduces support for configuring a custom server identity certificate path for the handshake protocol, improving flexibility and security in server deployments. The changes add a new `ConfigureCertificate` method to the builder API, update documentation, and refactor certificate loading logic to allow overriding the default certificate location.

**API and Builder Enhancements:**

* Added `ConfigureCertificate(string certificatePath)` to `INetworkApplicationBuilder` and its implementation, enabling users to specify a custom path for the server identity certificate during host construction. (`src/Nalix.Network.Hosting/INetworkApplicationBuilder.cs` [[1]](diffhunk://#diff-23b8dcc5694cc699c2ebc74fce0e998f5654ad8af717911d2d9f721fb31becebR49-R55) `src/Nalix.Network.Hosting/NetworkApplicationBuilder.cs` [[2]](diffhunk://#diff-7f5e45df85b647ccd9bb2c73776da122aa229346a87c4ab4c401cd4575dc87aeR318-R325)
* Updated the builder pipeline to call `HandshakeHandlers.SetCertificatePath` with the provided path, or fall back to default initialization if none is set. (`src/Nalix.Network.Hosting/NetworkApplicationBuilder.cs` [src/Nalix.Network.Hosting/NetworkApplicationBuilder.csR339-R347](diffhunk://#diff-7f5e45df85b647ccd9bb2c73776da122aa229346a87c4ab4c401cd4575dc87aeR339-R347))
* Extended the builder state with an `IdentityCertificatePath` property to track the configured certificate path. (`src/Nalix.Network.Hosting/Internal/HostingBuilderContext.cs` [src/Nalix.Network.Hosting/Internal/HostingBuilderContext.csR80-R84](diffhunk://#diff-abef9ff9a42f3938711f5a4b96e01009e494015ee677bd59f2b7fb0f7883d96dR80-R84))

**Handshake Protocol Refactoring:**

* Refactored `HandshakeHandlers` to support dynamic certificate loading via `Initialize()` (default path) and `SetCertificatePath(string)` (custom path), with robust error handling and thread safety. The certificate loading logic was moved into a private `LOAD_CERTIFICATE` method. (`src/Nalix.Runtime/Handlers/HandshakeHandlers.cs` [[1]](diffhunk://#diff-9690dbadfdf8caacca86ac328e3805f159af8a7778ce8f0fba13a4ea0b1e87acL33-R81) [[2]](diffhunk://#diff-9690dbadfdf8caacca86ac328e3805f159af8a7778ce8f0fba13a4ea0b1e87acR130-R205)

**Documentation Updates:**

* Updated API docs and conceptual guides to document the new `ConfigureCertificate` method and clarify how to override the default server certificate path. (`docs/api/hosting/network-application.md` [[1]](diffhunk://#diff-db4e2d15a6da6101b338444361d66d87e44d35a1d7728f6f1823428b283eae3aL54-R54) [[2]](diffhunk://#diff-db4e2d15a6da6101b338444361d66d87e44d35a1d7728f6f1823428b283eae3aR79); `docs/concepts/application/hosting-model.md` [[3]](diffhunk://#diff-cd7d3ea5db69944a9ee0e1c7682a315b6bc28f2c86afb67e75f3e3e09b2f3246L24-R25); `docs/concepts/security/handshake-protocol.md` [[4]](diffhunk://#diff-08f4e50522723742a8114b0e68c8b16ce830aed72c7f5613aa0df75c38e284c7L11-R13)

These changes make it easier to manage server identity securely and flexibly, especially in environments where the certificate location must be customized.## Summary

<!-- Briefly describe the purpose of this PR and what it implements or fixes. -->

Closes #<!-- issue number -->

---

## Type of Change

- [ ] 🐛 Bug fix
- [x] 🚀 Feature / enhancement
- [ ] ⚡ Performance improvement
- [ ] 🔧 Refactor
- [x] 📚 Documentation update
- [ ] 🔒 Security fix
- [ ] 🧪 Tests

---

## How to Test

<!-- Describe steps to verify this PR. -->

1.
2.
3.

---

## Screenshots (if applicable)

<!-- Add screenshots or videos for UI changes. Remove this section if not applicable. -->

---

## Additional Notes

<!-- Optional: breaking changes, dependencies, deployment notes, anything reviewers should know. -->

---

## Checklist

- [ ] Code follows project style guidelines (`.editorconfig`).
- [ ] Tests cover all changes.
- [ ] All tests pass locally (`dotnet test`).
- [ ] Documentation updated (if applicable).
- [ ] Self-reviewed my own code.
- [ ] No merge conflicts with `master`.
