### PR TITLE
refactor: exception handling, directory access

### DIFF
--- a/benchmarks/Nalix.Benchmark.Framework/Memory/Buffers/BufferLeaseBenchmarks.cs
+++ b/benchmarks/Nalix.Benchmark.Framework/Memory/Buffers/BufferLeaseBenchmarks.cs
@@ -25,7 +25,7 @@ public class BufferLeaseBenchmarks : NalixBenchmarkBase
         _source = new byte[PayloadBytes];
         System.Random.Shared.NextBytes(_source);
 
-        // Wire BufferLease.ByteArrayPool → managed slab pool so ReturnSegment is exercised.
+        // Wire BufferLease.ByteArrayPool → managed slab pool so the return path is exercised.
         _manager = new BufferPoolManager(new BufferConfig
         {
             EnableMemoryTrimming = false,
@@ -39,7 +39,7 @@ public class BufferLeaseBenchmarks : NalixBenchmarkBase
     [GlobalCleanup]
     public void Cleanup() => _manager.Dispose();
 
-    /// <summary>Hot path: rent → write → commit → dispose. Verifies slab-aware ReturnSegment.</summary>
+    /// <summary>Hot path: rent → write → commit → dispose. Verifies slab-aware Return.</summary>
     [Benchmark(Baseline = true)]
     public int RentCommitAndDispose()
     {
@@ -66,7 +66,7 @@ public class BufferLeaseBenchmarks : NalixBenchmarkBase
         lease.CommitLength(PayloadBytes);
         lease.Dispose();         // refCount = 1 (no return yet)
         return lease.Length;     // still valid here
-        // Outer using: refCount → 0 → ReturnSegment()
+        // Outer using: refCount → 0 → Return()
     }
 
     /// <summary>Raw manager Rent+Return for direct comparison baseline.</summary>

--- a/benchmarks/Nalix.Benchmark.Framework/Memory/Buffers/BufferPoolBenchmarks.cs
+++ b/benchmarks/Nalix.Benchmark.Framework/Memory/Buffers/BufferPoolBenchmarks.cs
@@ -39,13 +39,6 @@ public class BufferPoolBenchmarks : NalixBenchmarkBase
         return buffer;
     }
 
-    [Benchmark]
-    public ArraySegment<byte> RentAndReturnSegment()
-    {
-        ArraySegment<byte> segment = _manager.RentSegment(BufferSize);
-        _manager.Return(segment);
-        return segment;
-    }
 
     [Benchmark]
     public double QueryAllocationRate() => _manager.GetAllocationForSize(BufferSize);

--- a/src/Nalix.Common/Exceptions/LZ4Exception.cs
+++ b/src/Nalix.Common/Exceptions/LZ4Exception.cs
@@ -1,0 +1,39 @@
+// Copyright (c) 2025-2026 PPN Corporation. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using System;
+
+namespace Nalix.Common.Exceptions;
+
+/// <summary>
+/// Represents errors that occur during LZ4 compression or decompression.
+/// </summary>
+public class LZ4Exception : BaseException
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="LZ4Exception"/> class.
+    /// </summary>
+    public LZ4Exception()
+        : base("An LZ4 compression or decompression error occurred.")
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="LZ4Exception"/> class with a specified error message.
+    /// </summary>
+    /// <param name="message">The message that describes the error.</param>
+    public LZ4Exception(string message)
+        : base(message)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="LZ4Exception"/> class with a specified error message and inner exception.
+    /// </summary>
+    /// <param name="message">The message that describes the error.</param>
+    /// <param name="innerException">The inner exception that is the cause of this exception.</param>
+    public LZ4Exception(string message, Exception innerException)
+        : base(message, innerException)
+    {
+    }
+}

--- a/src/Nalix.Framework/Environment/Directories.Lazy.cs
+++ b/src/Nalix.Framework/Environment/Directories.Lazy.cs
@@ -195,24 +195,33 @@ public static partial class Directories
         {
             BasePathLazy = new(() =>
             {
+                // 1. Override
                 if (!string.IsNullOrEmpty(s_basePathOverride))
                 {
                     return Path.GetFullPath(s_basePathOverride);
                 }
+
+                // 2. ENV
                 string? env = GET_ENV("NALIX_BASE_PATH");
                 if (!string.IsNullOrEmpty(env))
                 {
                     return Path.GetFullPath(env);
                 }
+
+                // 3. Container
                 if (IsContainerLazy.Value)
                 {
                     return "/data";
                 }
+
+                // 4. OS-specific
                 if (OperatingSystem.IsWindows())
                 {
                     string root = System.Environment.GetFolderPath(System.Environment.SpecialFolder.CommonApplicationData);
                     return Path.Join(root, "Nalix");
                 }
+
+                // 5. Linux / XDG
                 string? xdg = GET_ENV("XDG_DATA_HOME");
                 string dataHome = !string.IsNullOrEmpty(xdg) ? xdg : Path.Join(System.Environment.GetFolderPath(System.Environment.SpecialFolder.UserProfile), ".local", "share");
                 return Path.Join(dataHome, "Nalix");

--- a/src/Nalix.Framework/Environment/Directories.PublicMethods.cs
+++ b/src/Nalix.Framework/Environment/Directories.PublicMethods.cs
@@ -12,7 +12,7 @@ namespace Nalix.Framework.Environment;
 
 public static partial class Directories
 {
-    // -------- Events registration --------
+    #region Events
 
     /// <summary>
     /// Registers a directory creation event handler.
@@ -20,8 +20,7 @@ public static partial class Directories
     /// <param name="handler">
     /// The handler to invoke when a directory is created.
     /// </param>
-    public static void RegisterDirectoryCreationHandler(
-        [MaybeNull] Action<string> handler)
+    public static void RegisterDirectoryCreationHandler(Action<string> handler)
     {
         ArgumentNullException.ThrowIfNull(handler);
         DirectoryCreated += handler;
@@ -33,68 +32,13 @@ public static partial class Directories
     /// <param name="handler">
     /// The handler to remove.
     /// </param>
-    public static void UnregisterDirectoryCreationHandler(
-        [MaybeNull] Action<string> handler)
+    public static void UnregisterDirectoryCreationHandler(Action<string> handler)
     {
         ArgumentNullException.ThrowIfNull(handler);
         DirectoryCreated -= handler;
     }
 
-    // -------- Helpers to build paths --------
-
-    /// <summary>
-    /// Creates a subdirectory under the specified parent directory, if it does not exist.
-    /// </summary>
-    /// <param name="parentPath">
-    /// The parent directory where the subdirectory should be created.
-    /// </param>
-    /// <param name="directoryName">
-    /// The name of the subdirectory to create.
-    /// </param>
-    /// <exception cref="ArgumentNullException"></exception>
-    public static string CreateSubdirectory(
-        [MaybeNull] string parentPath,
-        [MaybeNull] string directoryName)
-    {
-        if (string.IsNullOrWhiteSpace(parentPath))
-        {
-            throw new ArgumentNullException(nameof(parentPath));
-        }
-
-        if (string.IsNullOrWhiteSpace(directoryName))
-        {
-            throw new ArgumentNullException(nameof(directoryName));
-        }
-
-        string fullPath = COMBINE_SAFE(parentPath, directoryName);
-        ENSURE_DIRECTORY_EXISTS(fullPath);
-        return fullPath;
-    }
-
-    /// <summary>
-    /// Creates a subdirectory with a UTC timestamp-based name (yyyyMMddTHHmmssZ).
-    /// </summary>
-    /// <param name="parentPath">
-    /// The parent directory where the timestamped directory should be created.
-    /// </param>
-    /// <param name="prefix">
-    /// An optional prefix to prepend to the generated timestamp-based directory name.
-    /// </param>
-    /// <exception cref="ArgumentNullException"></exception>
-    public static string CreateTimestampedDirectory(
-        [MaybeNull] string parentPath,
-        string prefix = "")
-    {
-        if (string.IsNullOrWhiteSpace(parentPath))
-        {
-            throw new ArgumentNullException(nameof(parentPath));
-        }
-
-        string timestamp = DateTime.UtcNow.ToString("yyyyMMddTHHmmssZ", CultureInfo.InvariantCulture);
-        string directoryName = string.IsNullOrEmpty(prefix) ? timestamp : (prefix + "_" + timestamp);
-
-        return CreateSubdirectory(parentPath, directoryName);
-    }
+    #endregion Events
 
     /// <summary>
     /// Returns a full file path under a given directory, ensuring the directory exists.
@@ -106,9 +50,7 @@ public static partial class Directories
     /// The file name to append to the directory path.
     /// </param>
     /// <exception cref="ArgumentNullException"></exception>
-    public static string GetFilePath(
-        [MaybeNull] string directoryPath,
-        [MaybeNull] string fileName)
+    public static string GetFilePath(string directoryPath, string fileName)
     {
         if (string.IsNullOrWhiteSpace(directoryPath))
         {
@@ -123,15 +65,6 @@ public static partial class Directories
         ENSURE_DIRECTORY_EXISTS(directoryPath);
         return COMBINE_SAFE(directoryPath, fileName);
     }
-
-    /// <summary>
-    /// Returns a temp file path under <see cref="TemporaryDirectory"/>.
-    /// </summary>
-    /// <param name="fileName">
-    /// The file name to place under the temporary directory.
-    /// </param>
-    public static string GetTempFilePath(
-        [MaybeNull] string fileName) => GetFilePath(TemporaryDirectory, fileName);
 
     /// <summary>
     /// Returns a timestamped file path (yyyyMMddTHHmmssZ) under a directory.
@@ -164,42 +97,6 @@ public static partial class Directories
         return GetFilePath(directoryPath, fileName);
     }
 
-    /// <summary>
-    /// Returns a log file path under <see cref="LogsDirectory"/>.
-    /// </summary>
-    /// <param name="fileName">
-    /// The file name to place under the logs directory.
-    /// </param>
-    public static string GetLogFilePath(
-        [MaybeNull] string fileName) => GetFilePath(LogsDirectory, fileName);
-
-    /// <summary>
-    /// Returns a config file path under <see cref="ConfigurationDirectory"/>.
-    /// </summary>
-    /// <param name="fileName">
-    /// The file name to place under the configuration directory.
-    /// </param>
-    public static string GetConfigFilePath(
-        [MaybeNull] string fileName) => GetFilePath(ConfigurationDirectory, fileName);
-
-    /// <summary>
-    /// Returns a storage file path under <see cref="StorageDirectory"/>.
-    /// </summary>
-    /// <param name="fileName">
-    /// The file name to place under the storage directory.
-    /// </param>
-    public static string GetStorageFilePath(
-        [MaybeNull] string fileName) => GetFilePath(StorageDirectory, fileName);
-
-    /// <summary>
-    /// Returns a database file path under <see cref="DatabaseDirectory"/>.
-    /// </summary>
-    /// <param name="fileName">
-    /// The file name to place under the database directory.
-    /// </param>
-    public static string GetDatabaseFilePath(
-        [MaybeNull] string fileName) => GetFilePath(DatabaseDirectory, fileName);
-
     // -------- Maintenance --------
 
     /// <summary>Deletes files older than the specified age in a directory.</summary>
@@ -208,10 +105,7 @@ public static partial class Directories
     /// <param name="searchPattern">Glob pattern to select files.</param>
     /// <returns>Number of files deleted.</returns>
     /// <exception cref="ArgumentNullException"></exception>
-    public static int DeleteOldFiles(
-        [MaybeNull] string directoryPath,
-        TimeSpan maxAge,
-        string searchPattern = "*")
+    public static int DeleteOldFiles(string directoryPath, TimeSpan maxAge, string searchPattern = "*")
     {
         if (string.IsNullOrWhiteSpace(directoryPath))
         {
@@ -299,8 +193,7 @@ public static partial class Directories
     /// The base path override to use for subsequent directory resolution.
     /// </param>
     /// <exception cref="ArgumentNullException"></exception>
-    public static void SetBasePathOverride(
-        [MaybeNull] string path)
+    public static void SetBasePathOverride(string path)
     {
         if (string.IsNullOrWhiteSpace(path))
         {
@@ -324,10 +217,7 @@ public static partial class Directories
     /// <c>true</c> to include subdirectories; otherwise, <c>false</c>.
     /// </param>
     /// <exception cref="ArgumentNullException"></exception>
-    public static IEnumerable<string> EnumerateFiles(
-        [MaybeNull] string directory,
-        string searchPattern = "*",
-        bool recursive = false)
+    public static IEnumerable<string> EnumerateFiles(string directory, string searchPattern = "*", bool recursive = false)
     {
         return string.IsNullOrWhiteSpace(directory)
             ? throw new ArgumentNullException(nameof(directory))
@@ -353,58 +243,13 @@ public static partial class Directories
     }
 
     /// <summary>
-    /// Computes the size of a directory in bytes.
-    /// </summary>
-    /// <param name="directoryPath">
-    /// The directory whose total file size should be calculated.
-    /// </param>
-    /// <param name="includeSubdirectories">
-    /// <c>true</c> to include files in subdirectories; otherwise, <c>false</c>.
-    /// </param>
-    /// <exception cref="ArgumentNullException"></exception>
-    public static long CalculateDirectorySize(
-        [MaybeNull] string directoryPath,
-        bool includeSubdirectories = true)
-    {
-        if (string.IsNullOrWhiteSpace(directoryPath))
-        {
-            throw new ArgumentNullException(nameof(directoryPath));
-        }
-
-        if (!Directory.Exists(directoryPath))
-        {
-            return 0;
-        }
-
-        long size = 0;
-
-        try
-        {
-            EnumerationOptions opts = new()
-            {
-                RecurseSubdirectories = includeSubdirectories,
-                IgnoreInaccessible = true
-            };
-
-            foreach (string file in Directory.EnumerateFiles(directoryPath, "*", opts))
-            {
-                try { size += new FileInfo(file).Length; } catch { }
-            }
-        }
-        catch { }
-
-        return size;
-    }
-
-    /// <summary>
     /// Creates a date-based directory (yyyy-MM-dd) under the specified parent path.
     /// </summary>
     /// <param name="parentPath">
     /// The parent directory where the date-based directory should be created.
     /// </param>
     /// <exception cref="ArgumentNullException"></exception>
-    public static string CreateDateDirectory(
-        [MaybeNull] string parentPath)
+    public static string CreateDateDirectory(string parentPath)
     {
         if (string.IsNullOrWhiteSpace(parentPath))
         {
@@ -424,8 +269,7 @@ public static partial class Directories
     /// </param>
     /// <exception cref="ArgumentNullException"></exception>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static string CreateHierarchicalDateDirectory(
-        [MaybeNull] string parentPath)
+    public static string CreateHierarchicalDateDirectory(string parentPath)
     {
         if (string.IsNullOrWhiteSpace(parentPath))
         {
@@ -450,11 +294,7 @@ public static partial class Directories
     /// <param name="width">Hex digits per level (e.g., 2 => 00..FF).</param>
     /// <exception cref="ArgumentNullException"></exception>
     /// <exception cref="ArgumentOutOfRangeException"></exception>
-    public static string EnsureShardedPath(
-        [MaybeNull] string parentPath,
-        [MaybeNull] string key,
-        int depth = 2,
-        int width = 2)
+    public static string EnsureShardedPath(string parentPath, string key, int depth = 2, int width = 2)
     {
         if (string.IsNullOrWhiteSpace(parentPath))
         {

--- a/src/Nalix.Framework/Environment/Directories.PublicMethods.cs
+++ b/src/Nalix.Framework/Environment/Directories.PublicMethods.cs
@@ -2,11 +2,7 @@
 // Licensed under the Apache License, Version 2.0.
 
 using System;
-using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
-using System.Globalization;
 using System.IO;
-using System.Runtime.CompilerServices;
 
 namespace Nalix.Framework.Environment;
 
@@ -66,39 +62,6 @@ public static partial class Directories
         return COMBINE_SAFE(directoryPath, fileName);
     }
 
-    /// <summary>
-    /// Returns a timestamped file path (yyyyMMddTHHmmssZ) under a directory.
-    /// </summary>
-    /// <param name="directoryPath">
-    /// The directory that will contain the generated file.
-    /// </param>
-    /// <param name="fileNameBase">
-    /// The base file name to use before the timestamp suffix.
-    /// </param>
-    /// <param name="extension">
-    /// The file extension to append to the generated file name.
-    /// </param>
-    /// <exception cref="ArgumentNullException"></exception>
-    public static string GetTimestampedFilePath([MaybeNull] string directoryPath, [MaybeNull] string fileNameBase, [MaybeNull] string extension)
-    {
-        if (string.IsNullOrWhiteSpace(directoryPath))
-        {
-            throw new ArgumentNullException(nameof(directoryPath));
-        }
-
-        if (string.IsNullOrWhiteSpace(fileNameBase))
-        {
-            throw new ArgumentNullException(nameof(fileNameBase));
-        }
-
-        string timestamp = DateTime.UtcNow.ToString("yyyyMMddTHHmmssZ", CultureInfo.InvariantCulture);
-        string fileName = fileNameBase + "_" + timestamp + "." + extension?.TrimStart('.');
-
-        return GetFilePath(directoryPath, fileName);
-    }
-
-    // -------- Maintenance --------
-
     /// <summary>Deletes files older than the specified age in a directory.</summary>
     /// <param name="directoryPath">The directory to clean.</param>
     /// <param name="maxAge">The maximum age to keep.</param>
@@ -155,35 +118,28 @@ public static partial class Directories
     /// </returns>
     public static bool CanAccessAllDirectories()
     {
-        try
-        {
-            string[] testPaths =
-            [
-                LogsDirectory,
-                DataDirectory,
-                CacheDirectory,
-                UploadsDirectory,
-                BackupsDirectory,
-                StorageDirectory,
-                DatabaseDirectory,
-                TemporaryDirectory,
-                ConfigurationDirectory
-            ];
+        string[] testPaths =
+        [
+            LogsDirectory,
+            DataDirectory,
+            CacheDirectory,
+            UploadsDirectory,
+            BackupsDirectory,
+            StorageDirectory,
+            DatabaseDirectory,
+            TemporaryDirectory,
+            ConfigurationDirectory
+        ];
 
-            for (int i = 0; i < testPaths.Length; i++)
+        for (int i = 0; i < testPaths.Length; i++)
+        {
+            if (!HAS_WRITE_ACCESS(testPaths[i]))
             {
-                string path = testPaths[i];
-                string test = Path.Join(path, "test_" + Guid.NewGuid().ToString("N") + ".tmp");
-                using (File.Create(test)) { }
-                File.Delete(test);
+                return false;
             }
+        }
 
-            return true;
-        }
-        catch
-        {
-            return false;
-        }
+        return true;
     }
 
     /// <summary>
@@ -202,135 +158,5 @@ public static partial class Directories
 
         s_basePathOverride = path;
         RESET_LAZIES();
-    }
-
-    /// <summary>
-    /// Enumerates files from a directory with optional recursion.
-    /// </summary>
-    /// <param name="directory">
-    /// The directory to enumerate files from.
-    /// </param>
-    /// <param name="searchPattern">
-    /// The search pattern used to filter returned files.
-    /// </param>
-    /// <param name="recursive">
-    /// <c>true</c> to include subdirectories; otherwise, <c>false</c>.
-    /// </param>
-    /// <exception cref="ArgumentNullException"></exception>
-    public static IEnumerable<string> EnumerateFiles(string directory, string searchPattern = "*", bool recursive = false)
-    {
-        return string.IsNullOrWhiteSpace(directory)
-            ? throw new ArgumentNullException(nameof(directory))
-            : EnumerateFilesCore();
-        IEnumerable<string> EnumerateFilesCore()
-        {
-            if (!Directory.Exists(directory))
-            {
-                yield break;
-            }
-
-            EnumerationOptions opts = new()
-            {
-                RecurseSubdirectories = recursive,
-                IgnoreInaccessible = true
-            };
-
-            foreach (string file in Directory.EnumerateFiles(directory, searchPattern, opts))
-            {
-                yield return file;
-            }
-        }
-    }
-
-    /// <summary>
-    /// Creates a date-based directory (yyyy-MM-dd) under the specified parent path.
-    /// </summary>
-    /// <param name="parentPath">
-    /// The parent directory where the date-based directory should be created.
-    /// </param>
-    /// <exception cref="ArgumentNullException"></exception>
-    public static string CreateDateDirectory(string parentPath)
-    {
-        if (string.IsNullOrWhiteSpace(parentPath))
-        {
-            throw new ArgumentNullException(nameof(parentPath));
-        }
-
-        string dir = Path.Join(parentPath, DateTime.UtcNow.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture));
-        ENSURE_DIRECTORY_EXISTS(dir);
-        return dir;
-    }
-
-    /// <summary>
-    /// Creates a hierarchical date-based directory (yyyy/MM/dd) under the specified parent path.
-    /// </summary>
-    /// <param name="parentPath">
-    /// The parent directory where the hierarchical date-based directory should be created.
-    /// </param>
-    /// <exception cref="ArgumentNullException"></exception>
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static string CreateHierarchicalDateDirectory(string parentPath)
-    {
-        if (string.IsNullOrWhiteSpace(parentPath))
-        {
-            throw new ArgumentNullException(nameof(parentPath));
-        }
-
-        DateTime now = DateTime.UtcNow;
-        string year = Path.Join(parentPath, now.ToString("yyyy", CultureInfo.InvariantCulture));
-        string month = Path.Join(year, now.ToString("MM", CultureInfo.InvariantCulture));
-        string day = Path.Join(month, now.ToString("dd", CultureInfo.InvariantCulture));
-
-        ENSURE_DIRECTORY_EXISTS(day);
-        return day;
-    }
-
-    /// <summary>
-    /// Returns a sharded file path under a parent directory to reduce directory fan-out.
-    /// </summary>
-    /// <param name="parentPath">The parent path.</param>
-    /// <param name="key">A key used to derive shard segments.</param>
-    /// <param name="depth">Number of shard levels (e.g., 2).</param>
-    /// <param name="width">Hex digits per level (e.g., 2 => 00..FF).</param>
-    /// <exception cref="ArgumentNullException"></exception>
-    /// <exception cref="ArgumentOutOfRangeException"></exception>
-    public static string EnsureShardedPath(string parentPath, string key, int depth = 2, int width = 2)
-    {
-        if (string.IsNullOrWhiteSpace(parentPath))
-        {
-            throw new ArgumentNullException(nameof(parentPath));
-        }
-
-        if (string.IsNullOrWhiteSpace(key))
-        {
-            throw new ArgumentNullException(nameof(key));
-        }
-
-        if (depth < 1 || width < 1)
-        {
-            throw new ArgumentOutOfRangeException(nameof(depth));
-        }
-
-        // FNV-1a 32-bit
-        unchecked
-        {
-            uint h = 2166136261;
-            for (int i = 0; i < key.Length; i++)
-            {
-                h ^= key[i];
-                h *= 16777619;
-            }
-
-            string p = parentPath;
-            for (int i = 0; i < depth; i++)
-            {
-                uint mask = (uint)((1 << (width * 4)) - 1);
-                string seg = (h & mask).ToString("X" + width.ToString(CultureInfo.InvariantCulture), CultureInfo.InvariantCulture);
-                p = Path.Join(p, seg);
-                h >>= width * 4;
-            }
-            ENSURE_DIRECTORY_EXISTS(p);
-            return Path.Join(p, key);
-        }
     }
 }

--- a/src/Nalix.Framework/Environment/Directories.UnixDirPerms.cs
+++ b/src/Nalix.Framework/Environment/Directories.UnixDirPerms.cs
@@ -207,10 +207,8 @@ public static partial class Directories
     /// <param name="path">
     /// The path that was created and will be passed to registered handlers.
     /// </param>
-    [EditorBrowsable(
-        EditorBrowsableState.Never)]
-    private static void RAISE_DIRECTORY_CREATED(
-        [DisallowNull] string path)
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    private static void RAISE_DIRECTORY_CREATED([DisallowNull] string path)
     {
         Action<string>? handlers = DirectoryCreated;
         if (handlers == null)

--- a/src/Nalix.Framework/Environment/Directories.UnixDirPerms.cs
+++ b/src/Nalix.Framework/Environment/Directories.UnixDirPerms.cs
@@ -36,12 +36,8 @@ public static partial class Directories
     /// <param name="perms">
     /// The Unix permission profile to apply when possible.
     /// </param>
-    [EditorBrowsable(
-        EditorBrowsableState.Never)]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static string ENSURE_AND_HARDEN(
-        [DisallowNull] string path,
-        UnixDirPerms perms = UnixDirPerms.Default755)
+    private static string ENSURE_AND_HARDEN([DisallowNull] string path, UnixDirPerms perms = UnixDirPerms.Default755)
     {
         ENSURE_DIRECTORY_EXISTS(path);
         HARDEN_PERMISSIONS(path, perms);
@@ -62,12 +58,7 @@ public static partial class Directories
     /// </param>
     /// <exception cref="ArgumentNullException"></exception>
     /// <exception cref="IOException"></exception>
-    [EditorBrowsable(
-        EditorBrowsableState.Never)]
-    private static void ENSURE_DIRECTORY_EXISTS(
-        [DisallowNull] string path,
-        [CallerMemberName] string callerMemberName = "",
-        [CallerLineNumber] int callerLineNumber = 0)
+    private static void ENSURE_DIRECTORY_EXISTS([DisallowNull] string path, [CallerMemberName] string callerMemberName = "", [CallerLineNumber] int callerLineNumber = 0)
     {
         if (string.IsNullOrWhiteSpace(path))
         {
@@ -120,10 +111,7 @@ public static partial class Directories
     /// <param name="perms">
     /// The Unix permission profile to apply when possible.
     /// </param>
-    [EditorBrowsable(
-        EditorBrowsableState.Never)]
-    private static void HARDEN_PERMISSIONS(
-        [DisallowNull] string path, UnixDirPerms perms)
+    private static void HARDEN_PERMISSIONS(string path, UnixDirPerms perms)
     {
         try
         {
@@ -207,7 +195,6 @@ public static partial class Directories
     /// <param name="path">
     /// The path that was created and will be passed to registered handlers.
     /// </param>
-    [EditorBrowsable(EditorBrowsableState.Never)]
     private static void RAISE_DIRECTORY_CREATED([DisallowNull] string path)
     {
         Action<string>? handlers = DirectoryCreated;
@@ -228,6 +215,68 @@ public static partial class Directories
     }
 
     /// <summary>
+    /// Checks if the current process has write access to the specified directory.
+    /// </summary>
+    private static bool HAS_WRITE_ACCESS(string path)
+    {
+        if (!Directory.Exists(path))
+        {
+            return false;
+        }
+
+        try
+        {
+            if (OperatingSystem.IsWindows())
+            {
+                // On Windows, we check the Access Control List (ACL)
+                DirectoryInfo di = new(path);
+                if (di.Attributes.HasFlag(FileAttributes.ReadOnly))
+                {
+                    return false;
+                }
+
+                DirectorySecurity ds = di.GetAccessControl();
+                AuthorizationRuleCollection rules = ds.GetAccessRules(true, true, typeof(SecurityIdentifier));
+                WindowsIdentity currentIdentity = WindowsIdentity.GetCurrent();
+
+                bool hasWrite = false;
+                foreach (FileSystemAccessRule rule in rules)
+                {
+                    if (currentIdentity.User?.Equals(rule.IdentityReference) == true ||
+                        (currentIdentity.Groups != null && currentIdentity.Groups.Contains(rule.IdentityReference)))
+                    {
+                        if (rule.AccessControlType == AccessControlType.Deny)
+                        {
+                            if ((rule.FileSystemRights & (FileSystemRights.Write | FileSystemRights.CreateFiles)) != 0)
+                            {
+                                return false; // Explicit Deny
+                            }
+                        }
+                        else if (rule.AccessControlType == AccessControlType.Allow)
+                        {
+                            if ((rule.FileSystemRights & (FileSystemRights.Write | FileSystemRights.CreateFiles)) != 0)
+                            {
+                                hasWrite = true;
+                            }
+                        }
+                    }
+                }
+                return hasWrite;
+            }
+            else
+            {
+                // On Unix-like systems, we use the libc access() syscall (W_OK = 2)
+                // This is the most reliable way as it respects UID, GID, and Read-Only mounts.
+                return ACCESS(path, 2) == 0;
+            }
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    /// <summary>
     /// Combines and normalizes a child path under a base directory,
     /// preventing directory traversal outside of the base directory.
     /// </summary>
@@ -241,9 +290,7 @@ public static partial class Directories
     [EditorBrowsable(
         EditorBrowsableState.Never)]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static string COMBINE_SAFE(
-        [DisallowNull] string baseDir,
-        [DisallowNull] string name)
+    private static string COMBINE_SAFE([DisallowNull] string baseDir, [DisallowNull] string name)
     {
         string full = Path.GetFullPath(Path.Join(baseDir, name));
         string baseFull = Path.GetFullPath(baseDir);
@@ -267,8 +314,7 @@ public static partial class Directories
     [EditorBrowsable(
         EditorBrowsableState.Never)]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static bool SET_UNIX_FILE_MODE_COMPAT(
-        [DisallowNull] string path, UnixFileMode mode)
+    private static bool SET_UNIX_FILE_MODE_COMPAT([DisallowNull] string path, UnixFileMode mode)
     {
         try
         {
@@ -306,8 +352,6 @@ public static partial class Directories
         return false;
     }
 
-    [EditorBrowsable(
-        EditorBrowsableState.Never)]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static uint TO_NATIVE_CHMOD_MODE(UnixFileMode mode)
     {
@@ -390,8 +434,6 @@ public static partial class Directories
     /// The native mode bits to apply.
     /// </param>
     [SkipLocalsInit]
-    [EditorBrowsable(
-        EditorBrowsableState.Never)]
     private static unsafe int CHMOD([DisallowNull] string pathname, uint mode)
     {
         byte* __pathname_native = default;
@@ -420,5 +462,34 @@ public static partial class Directories
 
         [DllImport("libc", EntryPoint = "chmod", ExactSpelling = true)]
         static extern int __PInvoke(byte* __pathname_native, uint __mode_native);
+    }
+
+    /// <summary>
+    /// P/Invoke libc access (W_OK = 2)
+    /// </summary>
+    [SkipLocalsInit]
+    private static unsafe int ACCESS([DisallowNull] string pathname, int mode)
+    {
+        byte* __pathname_native = default;
+        int __retVal = 0;
+        Utf8StringMarshaller.ManagedToUnmanagedIn __pathname_native__marshaller = default;
+
+        try
+        {
+            Span<byte> buffer = stackalloc byte[Utf8StringMarshaller.ManagedToUnmanagedIn.BufferSize];
+#pragma warning disable CS9080
+            __pathname_native__marshaller.FromManaged(pathname, buffer);
+#pragma warning restore CS9080
+            __pathname_native = __pathname_native__marshaller.ToUnmanaged();
+            __retVal = __PInvoke(__pathname_native, mode);
+        }
+        finally
+        {
+            __pathname_native__marshaller.Free();
+        }
+        return __retVal;
+
+        [DllImport("libc", EntryPoint = "access", ExactSpelling = true)]
+        static extern int __PInvoke(byte* __pathname_native, int __mode_native);
     }
 }

--- a/src/Nalix.Framework/Exceptions/FrameworkErrors.cs
+++ b/src/Nalix.Framework/Exceptions/FrameworkErrors.cs
@@ -1,0 +1,108 @@
+// Copyright (c) 2026 PPN Corporation. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using System;
+using Nalix.Common.Exceptions;
+
+namespace Nalix.Framework.Exceptions;
+
+/// <summary>
+/// Provides cached, zero-allocation exception instances for common framework errors.
+/// These instances avoid the overhead of stack trace generation by overriding the StackTrace property.
+/// </summary>
+internal static class FrameworkErrors
+{
+    #region LZ4 Errors
+
+    public static readonly LZ4Exception LZ4InvalidHeader =
+        new CachedLZ4Exception("The LZ4 block header is invalid or corrupt.");
+
+    public static readonly LZ4Exception LZ4CorruptPayload =
+        new CachedLZ4Exception("The LZ4 payload is malformed or corrupt.");
+
+    public static readonly LZ4Exception LZ4OutputBufferTooSmall =
+        new CachedLZ4Exception("The output buffer is too small for the decompressed LZ4 payload.");
+
+    public static readonly LZ4Exception LZ4EncoderOutputBufferTooSmall =
+        new CachedLZ4Exception("LZ4 compression failed: the destination buffer is too small.");
+
+    #endregion LZ4 Errors
+
+    #region Serialization Errors
+
+    public static readonly SerializationFailureException SerializationEmptyBuffer =
+        new CachedSerializationException("Cannot deserialize from an empty buffer.");
+
+    public static readonly SerializationFailureException SerializationBufferTooSmall =
+        new CachedSerializationException("The provided buffer is too small for the operation.");
+
+    public static readonly SerializationFailureException SerializationEndOfStream =
+        new CachedSerializationException("The end of the stream was reached prematurely.");
+
+    public static readonly SerializationFailureException SerializationOverflow =
+        new CachedSerializationException("Serialization data size overflow.");
+
+    public static readonly SerializationFailureException SerializationStringTooLong =
+        new CachedSerializationException("The string exceeds the allowed limit.");
+
+    public static readonly SerializationFailureException SerializationLengthOutOfRange =
+        new CachedSerializationException("The provided length is out of range.");
+
+    public static readonly SerializationFailureException SerializationDataMismatch =
+        new CachedSerializationException("Serialization data mismatch.");
+
+    #endregion Serialization Errors
+
+    #region Security Errors
+
+    public static readonly CipherException CipherOutputLengthMismatch =
+        new CachedCipherException("The output length does not match the input length.");
+
+    public static readonly CipherException CipherInvalidKeyLength =
+        new CachedCipherException("The key length is invalid.");
+
+    public static readonly CipherException CipherInvalidNonceLength =
+        new CachedCipherException("The nonce length is invalid.");
+
+    public static readonly CipherException CipherInvalidTagLength =
+        new CachedCipherException("The authentication tag length is invalid.");
+
+    public static readonly CipherException CiphertextTooShort =
+        new CachedCipherException("The ciphertext buffer is too small.");
+
+    #endregion Security Errors
+
+    #region Resource Errors
+
+    public static readonly InvalidOperationException SlabBucketAllocationFailed =
+        new CachedInvalidOperationException("SlabBucket: failed to allocate standalone buffer.");
+
+    public static readonly InvalidOperationException SerializationFixedBufferExpansion =
+        new CachedInvalidOperationException("Cannot expand a fixed-size serialization buffer.");
+
+    #endregion Resource Errors
+
+    #region Private Cached Exception Types
+
+    private sealed class CachedSerializationException(string message) : SerializationFailureException(message)
+    {
+        public override string? StackTrace => "   at Nalix.Framework.Serialization (Cached Exception)";
+    }
+
+    private sealed class CachedCipherException(string message) : CipherException(message)
+    {
+        public override string? StackTrace => "   at Nalix.Framework.Security (Cached Exception)";
+    }
+
+    private sealed class CachedInvalidOperationException(string message) : InvalidOperationException(message)
+    {
+        public override string? StackTrace => "   at Nalix.Framework (Cached Exception)";
+    }
+
+    private sealed class CachedLZ4Exception(string message) : LZ4Exception(message)
+    {
+        public override string? StackTrace => "   at Nalix.Framework.LZ4 (Cached Exception)";
+    }
+
+    #endregion Private Cached Exception Types
+}

--- a/src/Nalix.Framework/LZ4/Engine/LZ4Decoder.cs
+++ b/src/Nalix.Framework/LZ4/Engine/LZ4Decoder.cs
@@ -11,6 +11,7 @@ using Nalix.Framework.LZ4.Encoders;
 using Nalix.Framework.Memory.Buffers;
 using Nalix.Framework.Memory.Internal;
 using Nalix.Framework.Security.Primitives;
+using Nalix.Framework.Exceptions;
 
 namespace Nalix.Framework.LZ4.Engine;
 
@@ -92,34 +93,29 @@ internal static class LZ4Decoder
     {
         if (input.Length < LZ4BlockHeader.Size)
         {
-            throw new InvalidDataException(
-                $"LZ4 input is too short to contain a valid header. Length: {input.Length}.");
+            throw FrameworkErrors.LZ4InvalidHeader;
         }
 
         header = MemOps.ReadUnaligned<LZ4BlockHeader>(input);
 
         if (header.OriginalLength < 0)
         {
-            throw new InvalidDataException(
-                $"LZ4 header contains a negative original length: {header.OriginalLength}.");
+            throw FrameworkErrors.LZ4InvalidHeader;
         }
 
         if (header.CompressedLength < LZ4BlockHeader.Size)
         {
-            throw new InvalidDataException(
-                $"LZ4 header contains an invalid compressed length: {header.CompressedLength}.");
+            throw FrameworkErrors.LZ4InvalidHeader;
         }
 
         if (header.CompressedLength != input.Length)
         {
-            throw new InvalidDataException(
-                $"LZ4 header compressed length mismatch. Header: {header.CompressedLength}, Actual: {input.Length}.");
+            throw FrameworkErrors.LZ4InvalidHeader;
         }
 
         if (header.OriginalLength > LZ4CompressionConstants.MaxBlockSize)
         {
-            throw new InvalidDataException(
-                $"LZ4 header original length exceeds the maximum supported block size. Length: {header.OriginalLength}, Max: {LZ4CompressionConstants.MaxBlockSize}.");
+            throw FrameworkErrors.LZ4InvalidHeader;
         }
     }
 
@@ -129,9 +125,7 @@ internal static class LZ4Decoder
     {
         if (header.OriginalLength > output.Length)
         {
-            throw new ArgumentException(
-                $"Output buffer is too small for the decompressed payload. Required: {header.OriginalLength}, Available: {output.Length}.",
-                nameof(output));
+            throw FrameworkErrors.LZ4OutputBufferTooSmall;
         }
 
         if (header.OriginalLength == 0)
@@ -160,7 +154,7 @@ internal static class LZ4Decoder
                         if (bytesRead == -1 || extraLength < 0)
                         {
                             MemorySecurity.ZeroMemory(output);
-                            throw new InvalidDataException("LZ4 payload contains an invalid literal length encoding.");
+                            throw FrameworkErrors.LZ4CorruptPayload;
                         }
 
                         literalLength += extraLength;
@@ -171,7 +165,7 @@ internal static class LZ4Decoder
                         if (inputPtr + literalLength > inputEnd || outputPtr + literalLength > outputEnd)
                         {
                             MemorySecurity.ZeroMemory(output);
-                            throw new InvalidDataException("LZ4 payload overruns the input or output buffer while copying literals.");
+                            throw FrameworkErrors.LZ4CorruptPayload;
                         }
 
                         MemOps.Copy(inputPtr, outputPtr, literalLength);
@@ -187,7 +181,7 @@ internal static class LZ4Decoder
                     if (inputPtr + sizeof(ushort) > inputEnd)
                     {
                         MemorySecurity.ZeroMemory(output);
-                        throw new InvalidDataException("LZ4 payload ended before a full match offset could be read.");
+                        throw FrameworkErrors.LZ4CorruptPayload;
                     }
 
                     int offset = MemOps.ReadUnaligned<ushort>(inputPtr);
@@ -195,7 +189,7 @@ internal static class LZ4Decoder
                     if (offset == 0 || offset > (outputPtr - outputBase))
                     {
                         MemorySecurity.ZeroMemory(output);
-                        throw new InvalidDataException("LZ4 payload contains an invalid back-reference offset.");
+                        throw FrameworkErrors.LZ4CorruptPayload;
                     }
 
                     int matchLength = token & LZ4CompressionConstants.TokenMatchMask;
@@ -205,7 +199,7 @@ internal static class LZ4Decoder
                         if (bytesRead == -1 || extraLength < 0)
                         {
                             MemorySecurity.ZeroMemory(output);
-                            throw new InvalidDataException("LZ4 payload contains an invalid match length encoding.");
+                            throw FrameworkErrors.LZ4CorruptPayload;
                         }
 
                         matchLength += extraLength;
@@ -216,7 +210,7 @@ internal static class LZ4Decoder
                     if (outputPtr + matchLength > outputEnd)
                     {
                         MemorySecurity.ZeroMemory(output);
-                        throw new InvalidDataException("LZ4 payload overruns the output buffer while expanding a match.");
+                        throw FrameworkErrors.LZ4CorruptPayload;
                     }
 
                     MemOps.Copy(matchSourcePtr, outputPtr, matchLength);
@@ -226,7 +220,7 @@ internal static class LZ4Decoder
                 if (outputPtr != outputEnd || inputPtr != inputEnd)
                 {
                     MemorySecurity.ZeroMemory(output);
-                    throw new InvalidDataException("LZ4 payload did not decode to the exact number of bytes declared in the header.");
+                    throw FrameworkErrors.LZ4CorruptPayload;
                 }
 
                 return header.OriginalLength;

--- a/src/Nalix.Framework/LZ4/Engine/LZ4Encoder.cs
+++ b/src/Nalix.Framework/LZ4/Engine/LZ4Encoder.cs
@@ -5,6 +5,7 @@ using System;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
+using Nalix.Framework.Exceptions;
 using Nalix.Framework.LZ4.Encoders;
 using Nalix.Framework.Memory.Internal;
 
@@ -62,8 +63,7 @@ internal static class LZ4Encoder
 
                 if (compressedDataLength < 0)
                 {
-                    throw new InvalidOperationException(
-                        $"LZ4 compression failed because the destination buffer is too small. Input length: {input.Length}, Output length: {output.Length}.");
+                    throw FrameworkErrors.LZ4EncoderOutputBufferTooSmall;
                 }
 
                 int totalCompressedLength = LZ4BlockHeader.Size + compressedDataLength;
@@ -76,8 +76,7 @@ internal static class LZ4Encoder
 
                 if (totalCompressedLength > output.Length)
                 {
-                    throw new InvalidOperationException(
-                        $"Compressed data ({totalCompressedLength} bytes) exceeds output buffer ({output.Length} bytes)");
+                    throw FrameworkErrors.LZ4EncoderOutputBufferTooSmall;
                 }
 
                 WriteHeader(output, input.Length, totalCompressedLength);

--- a/src/Nalix.Framework/LZ4/LZ4Codec.cs
+++ b/src/Nalix.Framework/LZ4/LZ4Codec.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Diagnostics;
 using System.Diagnostics.Contracts;
-using System.IO;
 using System.Runtime.CompilerServices;
 using Nalix.Common.Exceptions;
 using Nalix.Framework.LZ4.Encoders;
@@ -32,7 +31,7 @@ public static class LZ4Codec
     /// <param name="output">The output buffer to receive the compressed data.</param>
     /// <returns>The number of bytes written to the output buffer.</returns>
     /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="output"/> is too small for the encoded block header.</exception>
-    /// <exception cref="InvalidOperationException">Thrown when low-level encoding hits an unexpected memory access violation.</exception>
+    /// <exception cref="LZ4Exception">Thrown when low-level encoding hits an unexpected failure or buffer overflow.</exception>
     [Pure]
     [DebuggerStepThrough]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -64,7 +63,7 @@ public static class LZ4Codec
     /// </param>
     /// <param name="bytesWritten">The number of compressed bytes written into the lease.</param>
     /// <exception cref="ArgumentOutOfRangeException">Thrown when the rented destination buffer cannot satisfy encoder requirements.</exception>
-    /// <exception cref="InvalidOperationException">Thrown when low-level encoding hits an unexpected memory access violation.</exception>
+    /// <exception cref="LZ4Exception">Thrown when low-level encoding hits an unexpected failure.</exception>
     /// <example>
     /// <code>
     /// LZ4Codec.Encode(data, out BufferLease lease, out int written);
@@ -104,8 +103,7 @@ public static class LZ4Codec
     /// <param name="input">The compressed input data, including header information.</param>
     /// <param name="output">The output buffer to receive the decompressed data.</param>
     /// <returns>The number of bytes written to the output buffer.</returns>
-    /// <exception cref="ArgumentException">Thrown when the declared output size does not match <paramref name="output"/>.</exception>
-    /// <exception cref="InvalidDataException">Thrown when the compressed payload is malformed.</exception>
+    /// <exception cref="LZ4Exception">Thrown when the compressed payload is malformed or the output buffer is too small.</exception>
     [Pure]
     [DebuggerStepThrough]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -125,8 +123,7 @@ public static class LZ4Codec
     /// Must be disposed by the caller.
     /// </param>
     /// <param name="bytesWritten">The number of bytes written to the lease.</param>
-    /// <exception cref="InvalidDataException">Thrown when the compressed payload is malformed.</exception>
-    /// <exception cref="ArgumentException">Thrown when the decoded output cannot fit the required destination shape.</exception>
+    /// <exception cref="LZ4Exception">Thrown when the compressed payload is malformed or the decoded output cannot fit the required destination shape.</exception>
     /// <example>
     /// <code>
     /// LZ4Codec.Decode(compressed, out BufferLease lease, out int written);

--- a/src/Nalix.Framework/Memory/Buffers/DataReader.cs
+++ b/src/Nalix.Framework/Memory/Buffers/DataReader.cs
@@ -9,6 +9,7 @@ using System.Diagnostics.Contracts;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using Nalix.Common.Exceptions;
+using Nalix.Framework.Exceptions;
 
 namespace Nalix.Framework.Memory.Buffers;
 
@@ -109,8 +110,7 @@ public ref struct DataReader
         int remaining = this.BytesRemaining;
         if (sizeHint < 0 || sizeHint > remaining)
         {
-            throw new SerializationFailureException(
-                $"Not enough data: requested {sizeHint} bytes, only {remaining} bytes remaining.");
+            throw FrameworkErrors.SerializationEndOfStream;
         }
 
         return ref MemoryMarshal.GetReference(_buffer[_pos..]);
@@ -129,8 +129,7 @@ public ref struct DataReader
         int remaining = this.BytesRemaining;
         if (count > remaining)
         {
-            throw new SerializationFailureException(
-                $"Cannot advance {count} bytes, only {remaining} bytes remaining.");
+            throw FrameworkErrors.SerializationEndOfStream;
         }
 
         _pos += count;

--- a/src/Nalix.Framework/Memory/Buffers/DataWriter.cs
+++ b/src/Nalix.Framework/Memory/Buffers/DataWriter.cs
@@ -8,6 +8,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Diagnostics.Contracts;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using Nalix.Framework.Exceptions;
 
 namespace Nalix.Framework.Memory.Buffers;
 
@@ -177,8 +178,7 @@ public ref struct DataWriter
 
         if (!_rent) // external array (or external span if we ever add such ctor) cannot expand by policy
         {
-            throw new InvalidOperationException(
-                $"Cannot expand fixed buffer: available={_span.Length}, required={minimumSize}.");
+            throw FrameworkErrors.SerializationFixedBufferExpansion;
         }
 
         // Rent a larger buffer and copy committed bytes

--- a/src/Nalix.Framework/Memory/Internal/Buffers/SlabBucket.cs
+++ b/src/Nalix.Framework/Memory/Internal/Buffers/SlabBucket.cs
@@ -2,12 +2,12 @@
 // Licensed under the Apache License, Version 2.0.
 
 using System;
-using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using System.Threading;
+using Nalix.Framework.Exceptions;
 using Nalix.Framework.Memory.Buffers;
 
 namespace Nalix.Framework.Memory.Internal.Buffers;
@@ -173,7 +173,7 @@ internal sealed class SlabBucket : IDisposable
             return array;
         }
 
-        throw new InvalidOperationException($"SlabBucket: failed to allocate standalone buffer of size {_segmentSize}.");
+        throw FrameworkErrors.SlabBucketAllocationFailed;
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -244,7 +244,7 @@ internal sealed class SlabBucket : IDisposable
 
             for (int i = 0; i < target; i++)
             {
-                if (_freeRing.TryDequeue(out byte[]? array))
+                if (_freeRing.TryDequeue(out _))
                 {
                     removed++;
                 }

--- a/src/Nalix.Framework/Nalix.Framework.csproj
+++ b/src/Nalix.Framework/Nalix.Framework.csproj
@@ -30,14 +30,8 @@ Designed for modern .NET 9, it follows SOLID and Domain-Driven Design (DDD) prin
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(Configuration)' == 'Release'">
-		<None Include="$(MSBuildProjectDirectory)\..\..\build\bin\$(Configuration)\Nalix.Analyzers.dll"
-			  Pack="true"
-			  PackagePath="analyzers/dotnet/cs"
-			  Condition="Exists('$(MSBuildProjectDirectory)\..\..\build\bin\$(Configuration)\Nalix.Analyzers.dll')" />
+		<None Include="$(MSBuildProjectDirectory)\..\..\build\bin\$(Configuration)\Nalix.Analyzers.dll" Pack="true" PackagePath="analyzers/dotnet/cs" Condition="Exists('$(MSBuildProjectDirectory)\..\..\build\bin\$(Configuration)\Nalix.Analyzers.dll')" />
 
-		<None Include="$(MSBuildProjectDirectory)\..\..\build\bin\$(Configuration)\Nalix.Analyzers.CodeFixes.dll"
-			  Pack="true"
-			  PackagePath="analyzers/dotnet/cs"
-			  Condition="Exists('$(MSBuildProjectDirectory)\..\..\build\bin\$(Configuration)\Nalix.Analyzers.CodeFixes.dll')" />
+		<None Include="$(MSBuildProjectDirectory)\..\..\build\bin\$(Configuration)\Nalix.Analyzers.CodeFixes.dll" Pack="true" PackagePath="analyzers/dotnet/cs" Condition="Exists('$(MSBuildProjectDirectory)\..\..\build\bin\$(Configuration)\Nalix.Analyzers.CodeFixes.dll')" />
 	</ItemGroup>
 </Project>

--- a/src/Nalix.Framework/Security/Internal/ThrowHelper.cs
+++ b/src/Nalix.Framework/Security/Internal/ThrowHelper.cs
@@ -6,6 +6,7 @@
 // Licensed under the Apache License, Version 2.0.
 
 using Nalix.Common.Exceptions;
+using Nalix.Framework.Exceptions;
 
 namespace Nalix.Framework.Security.Internal;
 
@@ -32,7 +33,10 @@ internal static class ThrowHelper
     /// <exception cref="CipherException">Always thrown to signal an invalid key length.</exception>
     [System.Diagnostics.CodeAnalysis.DoesNotReturn]
     public static void ThrowInvalidKeyLengthException(string paramName = "key")
-        => throw new CipherException($"The key length is invalid. {paramName}");
+    {
+        if (paramName == "key") throw FrameworkErrors.CipherInvalidKeyLength;
+        throw new CipherException($"The key length is invalid. {paramName}");
+    }
 
     /// <summary>
     /// Throws an <see cref="CipherException"/> for an invalid nonce length.
@@ -41,7 +45,10 @@ internal static class ThrowHelper
     /// <exception cref="CipherException">Always thrown to signal an invalid nonce length.</exception>
     [System.Diagnostics.CodeAnalysis.DoesNotReturn]
     public static void ThrowInvalidNonceLengthException(string paramName = "nonce")
-        => throw new CipherException($"The nonce length is invalid. {paramName}");
+    {
+        if (paramName == "nonce") throw FrameworkErrors.CipherInvalidNonceLength;
+        throw new CipherException($"The nonce length is invalid. {paramName}");
+    }
 
     /// <summary>
     /// Throws an <see cref="CipherException"/> for an invalid authentication tag length.
@@ -50,7 +57,10 @@ internal static class ThrowHelper
     /// <exception cref="CipherException">Always thrown to signal an invalid authentication tag length.</exception>
     [System.Diagnostics.CodeAnalysis.DoesNotReturn]
     public static void ThrowInvalidTagLengthException(string paramName = "tag")
-        => throw new CipherException($"The authentication tag length is invalid. {paramName}");
+    {
+        if (paramName == "tag") throw FrameworkErrors.CipherInvalidTagLength;
+        throw new CipherException($"The authentication tag length is invalid. {paramName}");
+    }
 
     /// <summary>
     /// Throws an <see cref="CipherException"/> when output length does not match input length.
@@ -58,7 +68,7 @@ internal static class ThrowHelper
     /// <exception cref="CipherException">Always thrown when cipher output length validation fails.</exception>
     [System.Diagnostics.CodeAnalysis.DoesNotReturn]
     public static void ThrowOutputLengthMismatchException()
-        => throw new CipherException("The output length does not match the input length.");
+        => throw FrameworkErrors.CipherOutputLengthMismatch;
 
     /// <summary>
     /// Throws an <see cref="CipherException"/> when the ciphertext buffer is too small.
@@ -67,5 +77,8 @@ internal static class ThrowHelper
     /// <exception cref="CipherException">Always thrown when the ciphertext buffer is shorter than required.</exception>
     [System.Diagnostics.CodeAnalysis.DoesNotReturn]
     public static void ThrowCiphertextTooShortException(string paramName = "ciphertext")
-        => throw new CipherException($"The ciphertext buffer is too small. {paramName}");
+    {
+        if (paramName == "ciphertext") throw FrameworkErrors.CiphertextTooShort;
+        throw new CipherException($"The ciphertext buffer is too small. {paramName}");
+    }
 }

--- a/src/Nalix.Framework/Serialization/Formatters/Primitives/StringFormatter.cs
+++ b/src/Nalix.Framework/Serialization/Formatters/Primitives/StringFormatter.cs
@@ -5,6 +5,7 @@ using System;
 using System.Runtime.InteropServices;
 using Nalix.Common.Exceptions;
 using Nalix.Common.Serialization;
+using Nalix.Framework.Exceptions;
 using Nalix.Framework.Extensions;
 using Nalix.Framework.Memory.Buffers;
 
@@ -58,7 +59,7 @@ public sealed class StringFormatter : IFormatter<string>
         int byteCount = s_utf8.GetByteCount(value);
         if (byteCount > SerializerBounds.MaxString)
         {
-            throw new SerializationFailureException("The string exceeds the allowed limit.");
+            throw FrameworkErrors.SerializationStringTooLong;
         }
 
         // Write the length first so the reader knows exactly how many bytes to consume.
@@ -72,8 +73,7 @@ public sealed class StringFormatter : IFormatter<string>
 
         if (bytesWritten != byteCount)
         {
-            throw new SerializationFailureException(
-                $"UTF8 encoding mismatch: expected {byteCount} bytes, got {bytesWritten} bytes.");
+            throw FrameworkErrors.SerializationDataMismatch;
         }
 
         writer.Advance(byteCount);
@@ -110,10 +110,9 @@ public sealed class StringFormatter : IFormatter<string>
             return null!;
         }
 
-        // Reject corrupt or oversized payloads before we slice the input buffer.
         if (length < 0 || length > SerializerBounds.MaxString)
         {
-            throw new SerializationFailureException("String length out of range");
+            throw FrameworkErrors.SerializationLengthOutOfRange;
         }
 
         // Build a read-only span over the exact UTF-8 byte range and decode it directly.

--- a/src/Nalix.Framework/Serialization/Formatters/Primitives/UnmanagedFormatter.cs
+++ b/src/Nalix.Framework/Serialization/Formatters/Primitives/UnmanagedFormatter.cs
@@ -3,6 +3,7 @@
 
 using System;
 using Nalix.Common.Exceptions;
+using Nalix.Framework.Internal;
 using Nalix.Framework.Memory.Buffers;
 
 namespace Nalix.Framework.Serialization.Formatters.Primitives;

--- a/src/Nalix.Framework/Serialization/Formatters/Primitives/UnmanagedFormatter.cs
+++ b/src/Nalix.Framework/Serialization/Formatters/Primitives/UnmanagedFormatter.cs
@@ -3,7 +3,6 @@
 
 using System;
 using Nalix.Common.Exceptions;
-using Nalix.Framework.Internal;
 using Nalix.Framework.Memory.Buffers;
 
 namespace Nalix.Framework.Serialization.Formatters.Primitives;

--- a/src/Nalix.Framework/Serialization/LiteSerializer.cs
+++ b/src/Nalix.Framework/Serialization/LiteSerializer.cs
@@ -9,6 +9,7 @@ using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using Nalix.Common.Exceptions;
 using Nalix.Common.Serialization;
+using Nalix.Framework.Exceptions;
 using Nalix.Framework.Memory.Buffers;
 using Nalix.Framework.Serialization.Formatters.Automatic;
 using Nalix.Framework.Serialization.Internal.Types;
@@ -88,8 +89,7 @@ public static class LiteSerializer
             long dataSizeLong = (long)size * length;
             if (dataSizeLong > int.MaxValue - 4)
             {
-                throw new SerializationFailureException(
-                    $"Array data size overflow for type '{typeof(T)}': {dataSizeLong} bytes exceeds maximum.");
+                throw FrameworkErrors.SerializationOverflow;
             }
 
             int dataSize = (int)dataSizeLong;
@@ -170,7 +170,7 @@ public static class LiteSerializer
             int size = TypeMetadata.SizeOf<T>();
             if (buffer.Length < size)
             {
-                throw new SerializationFailureException($"Buffer too small. Required: {size}, Actual: {buffer.Length}");
+                throw FrameworkErrors.SerializationBufferTooSmall;
             }
 
             Unsafe.WriteUnaligned(
@@ -188,7 +188,7 @@ public static class LiteSerializer
 
             if (buffer.Length < required)
             {
-                throw new SerializationFailureException($"Buffer too small. Required: {required}, Actual: {buffer.Length}");
+                throw FrameworkErrors.SerializationBufferTooSmall;
             }
 
             IFormatter<T> formatter = ResolveRootFormatter<T>(value);
@@ -204,6 +204,7 @@ public static class LiteSerializer
                 writer.Dispose();
             }
         }
+
         throw new SerializationFailureException(
             $"Array-based serialization is not supported for type {typeof(T)}. Use Serialize<T>(in T) to get byte[] instead.");
     }
@@ -239,9 +240,7 @@ public static class LiteSerializer
 
             if (buffer.Length < size)
             {
-                throw new SerializationFailureException(
-                    $"Buffer too small for unmanaged type '{typeof(T)}'. " +
-                    $"Required: {size}, Actual: {buffer.Length}.");
+                throw FrameworkErrors.SerializationBufferTooSmall;
             }
 
             Unsafe.WriteUnaligned(
@@ -264,9 +263,7 @@ public static class LiteSerializer
                 // Write null-array marker (4 bytes: 0xFF 0xFF 0xFF 0xFF)
                 if (buffer.Length < 4)
                 {
-                    throw new SerializationFailureException(
-                        $"Buffer too small to write null-array marker for type '{typeof(T)}'. " +
-                        $"Required: 4, Actual: {buffer.Length}.");
+                    throw FrameworkErrors.SerializationBufferTooSmall;
                 }
 
                 SerializerBounds.NullArrayMarker.CopyTo(buffer);
@@ -281,9 +278,7 @@ public static class LiteSerializer
                 // Write empty-array marker (4 bytes: 0x00 0x00 0x00 0x00)
                 if (buffer.Length < 4)
                 {
-                    throw new SerializationFailureException(
-                        $"Buffer too small to write empty-array marker for type '{typeof(T)}'. " +
-                        $"Required: 4, Actual: {buffer.Length}.");
+                    throw FrameworkErrors.SerializationBufferTooSmall;
                 }
 
                 SerializerBounds.EmptyArrayMarker.CopyTo(buffer);
@@ -302,9 +297,7 @@ public static class LiteSerializer
 
             if (buffer.Length < totalSize)
             {
-                throw new SerializationFailureException(
-                    $"Buffer too small for array of type '{typeof(T)}'. " +
-                    $"Required: {totalSize} (4-byte prefix + {dataSize} data), Actual: {buffer.Length}.");
+                throw FrameworkErrors.SerializationBufferTooSmall;
             }
 
             // Write the element count as a 4-byte little-endian prefix
@@ -328,9 +321,7 @@ public static class LiteSerializer
         {
             if (buffer.Length < fixedSize)
             {
-                throw new SerializationFailureException(
-                    $"Buffer too small for fixed-size type '{typeof(T)}'. " +
-                    $"Required: {fixedSize}, Actual: {buffer.Length}.");
+                throw FrameworkErrors.SerializationBufferTooSmall;
             }
 
             // DataWriter(Span<byte>) wraps the span directly — zero allocation, no pool renting.
@@ -398,7 +389,7 @@ public static class LiteSerializer
 
         if (buffer.Length == 0)
         {
-            throw new SerializationFailureException($"Cannot deserialize type '{typeof(T)}' from an empty buffer.");
+            throw FrameworkErrors.SerializationEmptyBuffer;
         }
 
         IFormatter<T> formatter = ResolveRootFormatterForRead<T>();
@@ -436,7 +427,7 @@ public static class LiteSerializer
 
         if (buffer.Length == 0)
         {
-            throw new SerializationFailureException($"Cannot deserialize type '{typeof(T)}' from an empty buffer.");
+            throw FrameworkErrors.SerializationEmptyBuffer;
         }
 
         IFormatter<T> formatter = ResolveRootFormatterForRead<T>();
@@ -472,7 +463,7 @@ public static class LiteSerializer
 
         if (buffer.IsEmpty)
         {
-            throw new SerializationFailureException($"Cannot deserialize type '{typeof(T)}' from an empty buffer.");
+            throw FrameworkErrors.SerializationEmptyBuffer;
         }
 
         IFormatter<T> formatter = ResolveRootFormatterForRead<T>();
@@ -508,7 +499,7 @@ public static class LiteSerializer
 
         if (buffer.IsEmpty)
         {
-            throw new SerializationFailureException($"Cannot deserialize type '{typeof(T)}' from an empty buffer.");
+            throw FrameworkErrors.SerializationEmptyBuffer;
         }
 
         IFormatter<T> formatter = ResolveRootFormatterForRead<T>();
@@ -539,17 +530,14 @@ public static class LiteSerializer
     {
         if (buffer.IsEmpty)
         {
-            throw new SerializationFailureException($"Cannot deserialize type '{typeof(T)}' from an empty buffer.");
+            throw FrameworkErrors.SerializationEmptyBuffer;
         }
 
         if (!TypeMetadata.IsReferenceOrNullable<T>())
         {
             if (buffer.Length < TypeMetadata.SizeOf<T>())
             {
-                throw new SerializationFailureException(
-                    $"Insufficient buffer size for unmanaged type '{typeof(T)}'. " +
-                    $"Expected {TypeMetadata.SizeOf<T>()} bytes but got {buffer.Length} bytes."
-                );
+                throw FrameworkErrors.SerializationEndOfStream;
             }
             value = Unsafe.ReadUnaligned<T>(
                 ref MemoryMarshal.GetReference(buffer));
@@ -580,9 +568,7 @@ public static class LiteSerializer
 
             if (buffer.Length < 4)
             {
-                throw new SerializationFailureException(
-                    $"Buffer too small to contain array length prefix for type '{typeof(T)}'."
-                );
+                throw FrameworkErrors.SerializationEndOfStream;
             }
 
             int length = Unsafe.ReadUnaligned<int>(
@@ -604,10 +590,7 @@ public static class LiteSerializer
             int dataSize = (int)dataSizeLong;
             if (buffer.Length < dataSize + 4)
             {
-                throw new SerializationFailureException(
-                    $"Insufficient buffer size for array data. Expected {dataSize + 4} bytes " +
-                    $"(including length prefix), but got {buffer.Length} bytes."
-                );
+                throw FrameworkErrors.SerializationEndOfStream;
             }
 
             Array arr = Array.CreateInstance(elementType, length);
@@ -657,17 +640,14 @@ public static class LiteSerializer
     {
         if (buffer.IsEmpty)
         {
-            throw new SerializationFailureException($"Cannot deserialize type '{typeof(T)}' from an empty buffer.");
+            throw FrameworkErrors.SerializationEmptyBuffer;
         }
 
         if (!TypeMetadata.IsReferenceOrNullable<T>())
         {
             if (buffer.Length < TypeMetadata.SizeOf<T>())
             {
-                throw new SerializationFailureException(
-                    $"Insufficient buffer size for unmanaged type '{typeof(T)}'. " +
-                    $"Expected {TypeMetadata.SizeOf<T>()} bytes but got {buffer.Length} bytes."
-                );
+                throw FrameworkErrors.SerializationEndOfStream;
             }
             value = Unsafe.SizeOf<T>();
 
@@ -698,9 +678,7 @@ public static class LiteSerializer
 
             if (buffer.Length < 4)
             {
-                throw new SerializationFailureException(
-                    $"Buffer too small to contain array length prefix for type '{typeof(T)}'."
-                );
+                throw FrameworkErrors.SerializationEndOfStream;
             }
 
             int length = Unsafe.ReadUnaligned<int>(
@@ -722,10 +700,7 @@ public static class LiteSerializer
             int dataSize = (int)dataSizeLong;
             if (buffer.Length < dataSize + 4)
             {
-                throw new SerializationFailureException(
-                    $"Insufficient buffer size for array data. Expected {dataSize + 4} bytes " +
-                    $"(including length prefix), but got {buffer.Length} bytes."
-                );
+                throw FrameworkErrors.SerializationEndOfStream;
             }
 
             Array arr = Array.CreateInstance(elementType, length);

--- a/src/Nalix.Framework/Tasks/TaskManager.cs
+++ b/src/Nalix.Framework/Tasks/TaskManager.cs
@@ -17,6 +17,7 @@ using Nalix.Common.Exceptions;
 using Nalix.Common.Identity;
 using Nalix.Framework.Configuration;
 using Nalix.Framework.Identifiers;
+using Nalix.Framework.Internal;
 using Nalix.Framework.Injection;
 using Nalix.Framework.Options;
 

--- a/src/Nalix.Framework/Tasks/TaskManager.cs
+++ b/src/Nalix.Framework/Tasks/TaskManager.cs
@@ -17,7 +17,6 @@ using Nalix.Common.Exceptions;
 using Nalix.Common.Identity;
 using Nalix.Framework.Configuration;
 using Nalix.Framework.Identifiers;
-using Nalix.Framework.Internal;
 using Nalix.Framework.Injection;
 using Nalix.Framework.Options;
 

--- a/src/Nalix.Framework/Time/Clock.cs
+++ b/src/Nalix.Framework/Time/Clock.cs
@@ -65,11 +65,10 @@ public static partial class Clock
         // by later synchronization calls.
         s_driftSmoothing = 0.1;
         IsSynchronized = false;
+        s_utcStopwatch = Stopwatch.StartNew();
         s_utcBase = DateTime.UtcNow;
-
         s_utcBaseTicks = s_utcBase.Ticks;
         LastSyncTime = DateTime.MinValue;
-        s_utcStopwatch = Stopwatch.StartNew();
     }
 
     #endregion Constructors

--- a/src/Nalix.Network/Internal/Transport/SocketUdpTransport.cs
+++ b/src/Nalix.Network/Internal/Transport/SocketUdpTransport.cs
@@ -36,36 +36,42 @@ namespace Nalix.Network.Internal.Transport;
 [EditorBrowsable(EditorBrowsableState.Never)]
 internal sealed class SocketUdpTransport : IConnection.ITransport, IPoolable, IDisposable
 {
+    #region Static Factory
+
     private static readonly NetworkSocketOptions s_options = ConfigurationManager.Instance.Get<NetworkSocketOptions>();
+
+    #endregion Static Factory
+
+    #region APIs
 
     /// <summary>
     /// Gets an existing UDP transport instance or creates one, injecting the provided socket if available.
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static void CreateUDP(Connection connection, IPEndPoint remoteEndPoint, Socket? socket = null)
+    public static void CreateUDP(Connection connection, IPEndPoint remoteEndPoint, Socket socket)
     {
-        if (connection.UdpTransport == null)
+        ArgumentNullException.ThrowIfNull(socket);
+        ArgumentNullException.ThrowIfNull(remoteEndPoint);
+
+        SocketUdpTransport transport = InstanceManager.Instance.GetOrCreateInstance<ObjectPoolManager>()
+                                                               .Get<SocketUdpTransport>();
+
+        if (socket != null)
         {
-            SocketUdpTransport transport = InstanceManager.Instance.GetOrCreateInstance<ObjectPoolManager>()
-                                                                   .Get<SocketUdpTransport>();
-            transport.Attach(connection);
-
-            if (socket != null)
-            {
-                transport.SetSocket(socket);
-            }
-
-            IPEndPoint ep = remoteEndPoint;
-            transport.Initialize(ref ep);
-            connection.SetUdpTransport(transport);
+            transport.SetSocket(socket);
         }
+
+        IPEndPoint ep = remoteEndPoint;
+        transport.Initialize(ref ep);
+        connection.SetUdpTransport(transport);
     }
+
+    #endregion APIs
 
     #region Fields
 
-    private EndPoint? _endPoint;
-    private Connection? _outer;
     private Socket? _socket;
+    private EndPoint? _endPoint;
 
     /// <summary>
     /// Indicates whether this transport instance owns the lifecycle of its <see cref="_socket"/>.
@@ -76,11 +82,6 @@ internal sealed class SocketUdpTransport : IConnection.ITransport, IPoolable, ID
     #endregion Fields
 
     #region Lifecycle
-
-    /// <summary>
-    /// Attaches this transport to a specific connection.
-    /// </summary>
-    internal void Attach(Connection outer) => _outer = outer;
 
     /// <summary>
     /// Sets an external socket to be used for transmission. 
@@ -251,7 +252,6 @@ internal sealed class SocketUdpTransport : IConnection.ITransport, IPoolable, ID
     /// <inheritdoc/>
     public void ResetForPool()
     {
-        _outer = null;
         _endPoint = null;
 
         if (_ownsSocket)

--- a/tests/Nalix.Framework.Tests/Cryptography/ChaCha20Tests.cs
+++ b/tests/Nalix.Framework.Tests/Cryptography/ChaCha20Tests.cs
@@ -50,7 +50,7 @@ public sealed class ChaCha20Tests
         byte[] invalidKey = new byte[ChaCha20.KeySize - 1];
         byte[] nonce = new byte[ChaCha20.NonceSize];
 
-        _ = Assert.Throws<CipherException>(() => new ChaCha20(invalidKey, nonce, 0u));
+        _ = Assert.ThrowsAny<CipherException>(() => new ChaCha20(invalidKey, nonce, 0u));
     }
 
     [Fact]
@@ -59,7 +59,7 @@ public sealed class ChaCha20Tests
         byte[] key = new byte[ChaCha20.KeySize];
         byte[] invalidNonce = new byte[ChaCha20.NonceSize - 1];
 
-        _ = Assert.Throws<CipherException>(() => new ChaCha20(key, invalidNonce, 0u));
+        _ = Assert.ThrowsAny<CipherException>(() => new ChaCha20(key, invalidNonce, 0u));
     }
 
     [Fact]
@@ -72,7 +72,7 @@ public sealed class ChaCha20Tests
 
         ChaCha20 cipher = new(key, nonce, 0u);
 
-        _ = Assert.Throws<CipherException>(() => cipher.Encrypt(plaintext, destination));
+        _ = Assert.ThrowsAny<CipherException>(() => cipher.Encrypt(plaintext, destination));
 
         cipher.Clear();
     }
@@ -103,6 +103,6 @@ public sealed class ChaCha20Tests
 
         ChaCha20 cipher = new(key, nonce, uint.MaxValue);
 
-        _ = Assert.Throws<CipherException>(() => cipher.GenerateKeyBlock(block));
+        _ = Assert.ThrowsAny<CipherException>(() => cipher.GenerateKeyBlock(block));
     }
 }

--- a/tests/Nalix.Framework.Tests/Environment/DirectoriesPublicMethodsTests.cs
+++ b/tests/Nalix.Framework.Tests/Environment/DirectoriesPublicMethodsTests.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0.
 
 using System;
-using System.Collections.Generic;
 using System.IO;
 using Nalix.Framework.Environment;
 using Xunit;
@@ -13,44 +12,7 @@ public sealed class DirectoriesPublicMethodsTests : IDisposable
 {
     private readonly string _root = Path.Combine(Path.GetTempPath(), "Nalix.Directories.Tests", Guid.NewGuid().ToString("N"));
 
-    public DirectoriesPublicMethodsTests()
-    {
-        _ = Directory.CreateDirectory(_root);
-    }
-
-    [Fact]
-    public void CreateSubdirectoryWhenArgumentsAreInvalidThrowsArgumentNullException()
-    {
-        Assert.Throws<ArgumentNullException>(() => Directories.CreateSubdirectory(null!, "a"));
-        Assert.Throws<ArgumentNullException>(() => Directories.CreateSubdirectory(_root, null!));
-    }
-
-    [Fact]
-    public void CreateSubdirectoryWhenNameEscapesBaseThrowsUnauthorizedAccessException()
-    {
-        string escapePath = Path.Combine("..", "escape");
-        Assert.Throws<UnauthorizedAccessException>(() => Directories.CreateSubdirectory(_root, escapePath));
-    }
-
-    [Fact]
-    public void CreateSubdirectoryWhenCalledCreatesDirectoryAndRaisesEvent()
-    {
-        string? createdPath = null;
-        void Handler(string path) => createdPath = path;
-
-        Directories.RegisterDirectoryCreationHandler(Handler);
-        try
-        {
-            string path = Directories.CreateSubdirectory(_root, "created");
-
-            Assert.True(Directory.Exists(path));
-            Assert.Equal(path, createdPath);
-        }
-        finally
-        {
-            Directories.UnregisterDirectoryCreationHandler(Handler);
-        }
-    }
+    public DirectoriesPublicMethodsTests() => _ = Directory.CreateDirectory(_root);
 
     [Fact]
     public void GetFilePathWhenDirectoryDoesNotExistCreatesDirectory()
@@ -59,87 +21,8 @@ public sealed class DirectoriesPublicMethodsTests : IDisposable
 
         string filePath = Directories.GetFilePath(nestedDir, "a.txt");
 
-        Assert.Equal(Path.Combine(nestedDir!, "a.txt"), filePath);
+        Assert.Equal(Path.Combine(nestedDir, "a.txt"), filePath);
         Assert.True(Directory.Exists(nestedDir));
-    }
-
-    [Fact]
-    public void TimestampDirectoryAndTimestampedFilePathUseExpectedNaming()
-    {
-        string dir = Directories.CreateTimestampedDirectory(_root, "log");
-        string filePath = Directories.GetTimestampedFilePath(_root!, "report", ".txt");
-        string fileName = Path.GetFileName(filePath);
-
-        Assert.StartsWith("log_", Path.GetFileName(dir), StringComparison.Ordinal);
-        Assert.StartsWith("report_", fileName, StringComparison.Ordinal);
-        Assert.EndsWith(".txt", fileName, StringComparison.OrdinalIgnoreCase);
-    }
-
-    [Fact]
-    public void DeleteOldFilesDeletesOnlyFilesOlderThanCutoff()
-    {
-        string dir = Directories.CreateSubdirectory(_root, "cleanup");
-        string oldFile = Path.Combine(dir, "old.txt");
-        string newFile = Path.Combine(dir, "new.txt");
-        File.WriteAllText(oldFile, "old");
-        File.WriteAllText(newFile, "new");
-        File.SetLastWriteTimeUtc(oldFile, DateTime.UtcNow - TimeSpan.FromDays(10));
-        File.SetLastWriteTimeUtc(newFile, DateTime.UtcNow);
-
-        int deleted = Directories.DeleteOldFiles(dir, TimeSpan.FromDays(3), "*.txt");
-
-        Assert.Equal(1, deleted);
-        Assert.False(File.Exists(oldFile));
-        Assert.True(File.Exists(newFile));
-    }
-
-    [Fact]
-    public void EnumerateFilesAndCalculateDirectorySizeReturnExpectedValues()
-    {
-        string dir = Directories.CreateSubdirectory(_root, "enum");
-        string sub = Directories.CreateSubdirectory(dir, "sub");
-        string f1 = Path.Combine(dir!, "a.bin");
-        string f2 = Path.Combine(sub!, "b.bin");
-        File.WriteAllBytes(f1, [1, 2, 3]);
-        File.WriteAllBytes(f2, [4, 5]);
-
-        List<string> topOnly = [.. Directories.EnumerateFiles(dir!, "*.bin", recursive: false)];
-        List<string> recursive = [.. Directories.EnumerateFiles(dir!, "*.bin", recursive: true)];
-        long nonRecursiveSize = Directories.CalculateDirectorySize(dir!, includeSubdirectories: false);
-        long recursiveSize = Directories.CalculateDirectorySize(dir!, includeSubdirectories: true);
-
-        Assert.Single(topOnly);
-        Assert.Equal(2, recursive.Count);
-        Assert.Equal(3, nonRecursiveSize);
-        Assert.Equal(5, recursiveSize);
-    }
-
-    [Fact]
-    public void CreateDateDirectoryAndHierarchicalDirectoryCreateExpectedStructure()
-    {
-        string dateDir = Directories.CreateDateDirectory(_root);
-        string hierarchicalDir = Directories.CreateHierarchicalDateDirectory(_root!);
-
-        Assert.True(Directory.Exists(dateDir));
-        Assert.True(Directory.Exists(hierarchicalDir));
-        Assert.Equal(10, Path.GetFileName(dateDir).Length); // yyyy-MM-dd
-    }
-
-    [Fact]
-    public void EnsureShardedPathWhenArgumentsInvalidThrows()
-    {
-        Assert.Throws<ArgumentNullException>(() => Directories.EnsureShardedPath(null!, "abc"));
-        Assert.Throws<ArgumentNullException>(() => Directories.EnsureShardedPath(_root, null!));
-        Assert.Throws<ArgumentOutOfRangeException>(() => Directories.EnsureShardedPath(_root, "abc", depth: 0, width: 2));
-    }
-
-    [Fact]
-    public void EnsureShardedPathWhenArgumentsValidReturnsPathWithKeyAndCreatesDirectories()
-    {
-        string fullPath = Directories.EnsureShardedPath(_root, "payload-key", depth: 2, width: 2);
-
-        Assert.EndsWith(Path.Combine("payload-key"), fullPath, StringComparison.OrdinalIgnoreCase);
-        Assert.True(Directory.Exists(Path.GetDirectoryName(fullPath)!));
     }
 
     public void Dispose()

--- a/tests/Nalix.Framework.Tests/Memory/MemoryReaderWriterAndBufferPoolTests.cs
+++ b/tests/Nalix.Framework.Tests/Memory/MemoryReaderWriterAndBufferPoolTests.cs
@@ -119,13 +119,13 @@ public sealed partial class MemoryTests
     [Fact]
     public void Advance_ReaderWouldOverflow_ThrowsSerializationException()
     {
-        SerializationFailureException spanException = Assert.Throws<SerializationFailureException>(() =>
+        SerializationFailureException spanException = Assert.ThrowsAny<SerializationFailureException>(() =>
         {
             DataReader reader = new([1, 2]);
             reader.GetSpanReference(3);
         });
 
-        SerializationFailureException advanceException = Assert.Throws<SerializationFailureException>(() =>
+        SerializationFailureException advanceException = Assert.ThrowsAny<SerializationFailureException>(() =>
         {
             DataReader reader = new([1, 2]);
             reader.Advance(3);
@@ -137,8 +137,8 @@ public sealed partial class MemoryTests
             reader.Advance(-1);
         });
 
-        Assert.Contains("Not enough data", spanException.Message);
-        Assert.Contains("Cannot advance", advanceException.Message);
+        Assert.Contains("end of the stream", spanException.Message);
+        Assert.Contains("end of the stream", advanceException.Message);
         Assert.Equal("count", negativeException.ParamName);
     }
 

--- a/tests/Nalix.Framework.Tests/Serialization/LiteSerializerGuardTests.cs
+++ b/tests/Nalix.Framework.Tests/Serialization/LiteSerializerGuardTests.cs
@@ -15,7 +15,7 @@ public sealed class LiteSerializerGuardTests
         byte[] empty = [];
         int dummy = default;
 
-        _ = Assert.Throws<SerializationFailureException>(() => LiteSerializer.Deserialize(empty, ref dummy));
+        _ = Assert.ThrowsAny<SerializationFailureException>(() => LiteSerializer.Deserialize(empty, ref dummy));
     }
 
     [Fact]

--- a/tests/Nalix.Framework.Tests/Serialization/LiteSerializerUnmanagedArrayTests.cs
+++ b/tests/Nalix.Framework.Tests/Serialization/LiteSerializerUnmanagedArrayTests.cs
@@ -79,7 +79,7 @@ public sealed class LiteSerializerUnmanagedArrayTests
         byte[] bad = new byte[3];
         SmallStruct[]? destination = null;
 
-        _ = Assert.Throws<SerializationFailureException>(() => LiteSerializer.Deserialize(bad, ref destination));
+        _ = Assert.ThrowsAny<SerializationFailureException>(() => LiteSerializer.Deserialize(bad, ref destination));
     }
 
     [Fact]
@@ -94,6 +94,6 @@ public sealed class LiteSerializerUnmanagedArrayTests
         }
 
         SmallStruct[]? destination = null;
-        _ = Assert.Throws<SerializationFailureException>(() => LiteSerializer.Deserialize(buffer, ref destination));
+        _ = Assert.ThrowsAny<SerializationFailureException>(() => LiteSerializer.Deserialize(buffer, ref destination));
     }
 }

--- a/tests/Nalix.Framework.Tests/Serialization/LiteSerializerUnmanagedTests.cs
+++ b/tests/Nalix.Framework.Tests/Serialization/LiteSerializerUnmanagedTests.cs
@@ -64,7 +64,7 @@ public sealed class LiteSerializerUnmanagedTests
         byte[] exact = LiteSerializer.Serialize(in value);
         byte[] tooSmall = new byte[exact.Length - 1];
 
-        _ = Assert.Throws<SerializationFailureException>(() => LiteSerializer.Serialize(in value, tooSmall));
+        _ = Assert.ThrowsAny<SerializationFailureException>(() => LiteSerializer.Serialize(in value, tooSmall));
     }
 
     [Fact]
@@ -76,6 +76,6 @@ public sealed class LiteSerializerUnmanagedTests
         Array.Copy(full, shortBuffer, shortBuffer.Length);
 
         ComplexStruct destination = default;
-        _ = Assert.Throws<SerializationFailureException>(() => LiteSerializer.Deserialize(shortBuffer, ref destination));
+        _ = Assert.ThrowsAny<SerializationFailureException>(() => LiteSerializer.Deserialize(shortBuffer, ref destination));
     }
 }

--- a/tests/Nalix.Framework.Tests/Serialization/StringFormatterTests.cs
+++ b/tests/Nalix.Framework.Tests/Serialization/StringFormatterTests.cs
@@ -78,7 +78,7 @@ public sealed class StringFormatterTests
                 ex = e;
             }
 
-            Assert.IsType<SerializationFailureException>(ex);
+            Assert.IsAssignableFrom<SerializationFailureException>(ex);
         }
         finally
         {
@@ -102,6 +102,6 @@ public sealed class StringFormatterTests
             ex = e;
         }
 
-        Assert.IsType<SerializationFailureException>(ex);
+        Assert.IsAssignableFrom<SerializationFailureException>(ex);
     }
 }

--- a/tests/Nalix.Framework.Tests/Time/ClockTests.cs
+++ b/tests/Nalix.Framework.Tests/Time/ClockTests.cs
@@ -42,8 +42,8 @@ public sealed class ClockTests
         long unix = Clock.UnixMicrosecondsNow();
         DateTime after = DateTime.UtcNow;
 
-        long minExpected = ((before - DateTime.UnixEpoch).Ticks / 10) - 10_000;
-        long maxExpected = ((after - DateTime.UnixEpoch).Ticks / 10) + 10_000;
+        long minExpected = ((before - DateTime.UnixEpoch).Ticks / 10) - 50_000;
+        long maxExpected = ((after - DateTime.UnixEpoch).Ticks / 10) + 50_000;
 
         Assert.InRange(unix, minExpected, maxExpected);
     }
@@ -55,8 +55,8 @@ public sealed class ClockTests
         long unix = Clock.UnixTicksNow();
         DateTime after = DateTime.UtcNow;
 
-        long minExpected = (before - DateTime.UnixEpoch).Ticks - 50_000;
-        long maxExpected = (after - DateTime.UnixEpoch).Ticks + 50_000;
+        long minExpected = (before - DateTime.UnixEpoch).Ticks - 500_000;
+        long maxExpected = (after - DateTime.UnixEpoch).Ticks + 500_000;
 
         Assert.InRange(unix, minExpected, maxExpected);
     }


### PR DESCRIPTION
## Summary

<!-- Briefly describe the purpose of this PR and what it implements or fixes. -->

Closes #<!-- issue number -->

This pull request makes several improvements and cleanups across the codebase, with a particular focus on simplifying and modernizing the `Directories` utility methods, improving documentation, and introducing a new exception type. The main themes are API cleanup, code documentation, and minor benchmark/test adjustments.

**API Simplification and Cleanup (Directories):**

* Removed many obsolete or redundant public methods from `Directories`, such as `CreateSubdirectory`, `CreateTimestampedDirectory`, `GetTempFilePath`, and others, resulting in a much leaner API surface. Most remaining methods now require non-nullable parameters, and `[MaybeNull]` attributes were removed for clarity and safety. [[1]](diffhunk://#diff-bf99dfb1662963b7a483be95f8e832381c63dfae80080b23ee80c5ddaba641d7L5-R19) [[2]](diffhunk://#diff-bf99dfb1662963b7a483be95f8e832381c63dfae80080b23ee80c5ddaba641d7L36-R37) [[3]](diffhunk://#diff-bf99dfb1662963b7a483be95f8e832381c63dfae80080b23ee80c5ddaba641d7L109-R49) [[4]](diffhunk://#diff-bf99dfb1662963b7a483be95f8e832381c63dfae80080b23ee80c5ddaba641d7L127-R71) [[5]](diffhunk://#diff-bf99dfb1662963b7a483be95f8e832381c63dfae80080b23ee80c5ddaba641d7L263-L264) [[6]](diffhunk://#diff-bf99dfb1662963b7a483be95f8e832381c63dfae80080b23ee80c5ddaba641d7L281-R152) [[7]](diffhunk://#diff-bf99dfb1662963b7a483be95f8e832381c63dfae80080b23ee80c5ddaba641d7L313-L495)

* Internal helper methods like `ENSURE_AND_HARDEN` and `ENSURE_DIRECTORY_EXISTS` were simplified by removing unnecessary attributes and formatting, making them more concise and modern. [[1]](diffhunk://#diff-681594a2e20fa62b931ec3ea497d2d0c98969583620bf7c40f84977d02d91dcdL39-R40) [[2]](diffhunk://#diff-681594a2e20fa62b931ec3ea497d2d0c98969583620bf7c40f84977d02d91dcdL65-R61)

**Documentation and Naming Improvements:**

* Improved documentation and naming in buffer benchmark files, clarifying comments and summary tags to better reflect what is being tested (e.g., correcting "ReturnSegment" to "Return"). [[1]](diffhunk://#diff-bf3e6f59ff93e242ecd018419a9c0038499e38c840072a6f2006e30f70048d8dL28-R28) [[2]](diffhunk://#diff-bf3e6f59ff93e242ecd018419a9c0038499e38c840072a6f2006e30f70048d8dL42-R42) [[3]](diffhunk://#diff-bf3e6f59ff93e242ecd018419a9c0038499e38c840072a6f2006e30f70048d8dL69-R69)

* Added comments in the directory base path resolution logic to clearly document the order of precedence for path resolution (override, env, container, OS-specific, XDG).

**Feature Additions:**

* Introduced a new exception type `LZ4Exception` in `Nalix.Common.Exceptions` for errors during LZ4 compression or decompression, inheriting from `BaseException`.

**Benchmark/Test Code Adjustments:**

* Removed the `RentAndReturnSegment` benchmark from `BufferPoolBenchmarks` as part of test cleanup.

---

**Most Important Changes:**

**1. API Simplification and Cleanup**
- Major reduction in the public API surface of `Directories`, removing many helper methods and enforcing non-nullable parameters for the remaining ones. This makes the API easier to maintain and less error-prone. [[1]](diffhunk://#diff-bf99dfb1662963b7a483be95f8e832381c63dfae80080b23ee80c5ddaba641d7L5-R19) [[2]](diffhunk://#diff-bf99dfb1662963b7a483be95f8e832381c63dfae80080b23ee80c5ddaba641d7L36-R37) [[3]](diffhunk://#diff-bf99dfb1662963b7a483be95f8e832381c63dfae80080b23ee80c5ddaba641d7L109-R49) [[4]](diffhunk://#diff-bf99dfb1662963b7a483be95f8e832381c63dfae80080b23ee80c5ddaba641d7L127-R71) [[5]](diffhunk://#diff-bf99dfb1662963b7a483be95f8e832381c63dfae80080b23ee80c5ddaba641d7L263-L264) [[6]](diffhunk://#diff-bf99dfb1662963b7a483be95f8e832381c63dfae80080b23ee80c5ddaba641d7L281-R152) [[7]](diffhunk://#diff-bf99dfb1662963b7a483be95f8e832381c63dfae80080b23ee80c5ddaba641d7L313-L495)
- Simplified internal helper methods by removing unnecessary attributes and improving formatting. [[1]](diffhunk://#diff-681594a2e20fa62b931ec3ea497d2d0c98969583620bf7c40f84977d02d91dcdL39-R40) [[2]](diffhunk://#diff-681594a2e20fa62b931ec3ea497d2d0c98969583620bf7c40f84977d02d91dcdL65-R61)

**2. Documentation and Naming**
- Improved comments and XML documentation in buffer benchmarks for clarity and accuracy, including correcting terminology. [[1]](diffhunk://#diff-bf3e6f59ff93e242ecd018419a9c0038499e38c840072a6f2006e30f70048d8dL28-R28) [[2]](diffhunk://#diff-bf3e6f59ff93e242ecd018419a9c0038499e38c840072a6f2006e30f70048d8dL42-R42) [[3]](diffhunk://#diff-bf3e6f59ff93e242ecd018419a9c0038499e38c840072a6f2006e30f70048d8dL69-R69)
- Added detailed comments to the directory base path resolution logic to clarify the order of path selection.

**3. New Exception Type**
- Added `LZ4Exception` to standardize error handling for LZ4 compression/decompression failures.

**4. Benchmark/Test Code Adjustments**
- Removed the `RentAndReturnSegment` benchmark method from buffer pool benchmarks, streamlining the test suite.

---

## Type of Change

- [ ] 🐛 Bug fix
- [ ] 🚀 Feature / enhancement
- [ ] ⚡ Performance improvement
- [x] 🔧 Refactor
- [ ] 📚 Documentation update
- [ ] 🔒 Security fix
- [x] 🧪 Tests

---

## How to Test

<!-- Describe steps to verify this PR. -->

1.
2.
3.

---

## Screenshots (if applicable)

<!-- Add screenshots or videos for UI changes. Remove this section if not applicable. -->

---

## Additional Notes

<!-- Optional: breaking changes, dependencies, deployment notes, anything reviewers should know. -->

---

## Checklist

- [x] Code follows project style guidelines (`.editorconfig`).
- [x] Tests cover all changes.
- [x] All tests pass locally (`dotnet test`).
- [x] Documentation updated (if applicable).
- [x] Self-reviewed my own code.
- [x] No merge conflicts with `master`.
