### PR TITLE
refactor: packet registration, discovery

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,4 @@ site/
 .dotnethome/
 scratch/
 **/build/
+.nuget/

--- a/docs/api/framework/packets/packet-registry.md
+++ b/docs/api/framework/packets/packet-registry.md
@@ -1,45 +1,46 @@
 # Packet Registry
 
-This page covers the packet catalog APIs in `Nalix.Framework.DataFrames`.
+This page covers packet discovery and registry APIs in `Nalix.Framework.DataFrames`.
 
 ## Source mapping
 
 - `src/Nalix.Framework/DataFrames/PacketRegistryFactory.cs`
 - `src/Nalix.Framework/DataFrames/PacketRegistry.cs`
+- `src/Nalix.Framework/DataFrames/PacketRegister.cs`
 
 ## Main types
 
 - `PacketRegistryFactory`
 - `PacketRegistry`
+- `PacketRegister`
 
 ## Public members at a glance
 
 | Type | Public members |
 |---|---|
-| `PacketRegistryFactory` | `RegisterPacket`, `IncludeAssembly`, `IncludeCurrentDomain`, `IncludeNamespace`, `IncludeNamespaceRecursive`, `CreateCatalog`, `Compute` |
-| `PacketRegistry` | `IsKnownMagic`, `IsRegistered`, `TryDeserialize`, `TryGetDeserializer`, `DeserializerCount` |
-
-## Source notes
-
-The default factory now pre-registers these built-in packet types:
-
-- `Control`
-- `Handshake`
+| `PacketRegistryFactory` | `RegisterPacket`, `RegisterAllPackets`, `RegisterPacketAssembly`, `IncludeAssembly`, `IncludeCurrentDomain`, `RegisterCurrentDomainPackets`, `IncludeNamespace`, `IncludeNamespaceRecursive`, `CreateCatalog`, `Compute` |
+| `PacketRegistry` | `LoadFromNamespace(...)`, `LoadFromAssemblyPath(...)`, `IsKnownMagic`, `IsRegistered`, `Deserialize`, `TryDeserialize`, `DeserializerCount` |
+| `PacketRegister` | `CreateCatalogFromCurrentDomain(...)`, `CreateCatalogFromAssemblyPath(...)`, `CreateCatalogFromAssemblies(...)`, `CreateCatalogFromAssemblyPaths(...)` |
 
 ## PacketRegistryFactory
 
-`PacketRegistryFactory` builds an immutable `PacketRegistry` by registering packet types explicitly or by scanning assemblies and namespaces.
+`PacketRegistryFactory` is the fluent builder for an immutable `PacketRegistry`.
 
-It is the object you typically use when you want the same packet catalog on both server and client.
+The constructor pre-registers built-in signal packets:
 
-### Typical responsibilities
+- `Control`
+- `Handshake`
+- `SessionResume`
+- `Directive`
 
-- register built-in packet types
-- scan application assemblies or namespaces
-- compute magic numbers from packet types
-- build the frozen registry once, then reuse it
+### Common workflows
 
-## Basic usage
+- Register explicit packet types.
+- Register all packet types from an `Assembly`.
+- Register all packet types from a `.dll` file path.
+- Scan loaded assemblies, then filter by namespace.
+
+### Basic usage
 
 ```csharp
 PacketRegistryFactory factory = new();
@@ -50,89 +51,62 @@ factory.IncludeCurrentDomain()
 PacketRegistry registry = factory.CreateCatalog();
 ```
 
-### Common public methods
+### Assembly path usage
 
-- `RegisterPacket<TPacket>()`
-- `IncludeAssembly(assembly)`
-- `IncludeCurrentDomain()`
-- `IncludeNamespace(namespace)`
-- `IncludeNamespaceRecursive(namespace)`
-- `CreateCatalog()`
-- `Compute(type)`
+```csharp
+PacketRegistryFactory factory = new();
+factory.RegisterPacketAssembly(@"C:\apps\MyPackets.dll", requireAttribute: true);
 
-### Practical notes
-
-- `CreateCatalog()` is the handoff point from builder-style setup to runtime lookup.
-- `Compute(type)` is used to derive the magic number for a packet type.
-- the factory is the right place to centralize packet registration instead of sprinkling manual registrations across startup files.
-
-### Common pitfalls
-
-- calling `CreateCatalog()` before all packet assemblies are registered
-- registering the same packet type in multiple startup paths
-- assuming the catalog auto-discovers types without scanning or explicit registration
+PacketRegistry registry = factory.CreateCatalog();
+```
 
 ## PacketRegistry
 
-`PacketRegistry` is the immutable runtime catalog used by listeners and SDK sessions.
+`PacketRegistry` is the runtime, immutable, thread-safe lookup catalog.
 
-Once created, it is intended to be shared and treated as read-only.
+### What it provides
 
-### What it gives you
+- Fast magic-number lookup.
+- Packet-type registration checks.
+- Deserialization from raw packet bytes.
 
-- fast magic-number lookup
-- type registration checks
-- deserializer resolution
-- a single source of truth for packet discovery at runtime
-
-## Basic usage
+### Runtime use
 
 ```csharp
 if (registry.TryDeserialize(buffer, out IPacket? packet))
 {
     Console.WriteLine(packet.OpCode);
 }
-
-bool known = registry.IsKnownMagic(magic);
-bool registered = registry.IsRegistered<Handshake>();
 ```
 
-### Common public methods
+### Static convenience loaders
 
-- `IsKnownMagic(magic)`: Fast check for registered magic numbers.
-- `IsRegistered<TPacket>()`: Checks if a specific packet type is registered.
-- `Deserialize(raw)`: Decodes a packet from raw bytes; throws on failure.
-- `TryDeserialize(raw, out packet)`: Safely decodes a packet from raw bytes.
-- `DeserializerCount`: Gets the total number of registered packet types.
+- `LoadFromAssemblyPath(assemblyPath, requirePacketAttribute)`
+- `LoadFromNamespace(packetNamespace, recursive)`
+- `LoadFromNamespace(assemblyPath, packetNamespace, recursive)`
 
-### In-place Deserialization (Zero-allocation)
+## PacketRegister
 
-For mission-critical paths where performance is paramount, `PacketRegistry` supports deserializing data directly **into** an existing packet instance. This is essential for zero-allocation patterns when combined with packet pooling.
+`PacketRegister` is a static convenience API for quick catalog creation without manually handling a factory.
+
+### Helpers
+
+- `CreateCatalogFromCurrentDomain(...)`
+- `CreateCatalogFromAssemblyPath(...)`
+- `CreateCatalogFromAssemblies(...)`
+- `CreateCatalogFromAssemblyPaths(...)`
+
+### Example
 
 ```csharp
-// Example using an existing instance (e.g., from a pool)
-MyPacket reuse = pool.Rent();
-if (registry.TryDeserialize(buffer, ref reuse))
-{
-    // 'reuse' is now populated with data from buffer. 
-    // If the buffer contained a different packet type, TryDeserialize returns false.
-}
+PacketRegistry registry = PacketRegister.CreateCatalogFromCurrentDomain(requirePacketAttribute: true);
 ```
 
-#### New In-place Methods
-- **`Deserialize<TPacket>(raw, ref value)`**: Deserializes the buffer into the provided `ref value`. Returns the instance. Throws `InvalidOperationException` if the magic number doesn't match `TPacket`.
-- **`TryDeserialize<TPacket>(raw, ref value)`**: Attempts to populate `ref value`. Returns `false` if the magic number is unknown, the data is invalid, or the type doesn't match.
+## Practical notes
 
-### Practical notes
-
-- listeners use the registry while decoding inbound traffic
-- SDK sessions use the same registry to stay aligned with the server packet catalog
-- if the registry and packet types drift apart, deserialization usually fails fast rather than silently producing the wrong packet
-
-### Common pitfalls
-
-- treating the registry as mutable after startup
-- deserializing with a registry built from a different packet set than the sender
+- Use one shared registry instance across server runtime and client SDK whenever possible.
+- Prefer `ConfigurePacketRegistry(...)` in hosting if you already have a pre-built registry.
+- Prefer namespace filters when you want tighter discovery boundaries than full assembly scans.
 
 ## Related APIs
 
@@ -141,3 +115,4 @@ if (registry.TryDeserialize(buffer, ref reuse))
 - [Packet Contracts](../../common/packet-contracts.md)
 - [SDK Overview](../../sdk/index.md)
 - [Packet Dispatch](../../runtime/routing/packet-dispatch.md)
+- [Network Application (Hosting)](../../hosting/network-application.md)

--- a/docs/api/hosting/network-application.md
+++ b/docs/api/hosting/network-application.md
@@ -28,7 +28,7 @@ The public API surface revolves around two main types:
 graph LR
     subgraph Configuration ["Phase 1: Configuration"]
         Create["CreateBuilder()"] --> Config["Configure Loggers, Options, Hubs"]
-        Config --> Discover["AddPacket() & AddHandlers()"]
+        Config --> Discover["AddPacket()/AddPacketNamespace() & AddHandlers()"]
         Discover --> Bind["AddTcp() / AddUdp()"]
     end
 
@@ -51,7 +51,7 @@ graph LR
 | Type | Public members |
 |---|---|
 | `NetworkApplication` | `CreateBuilder()`, `ActivateAsync(...)`, `DeactivateAsync(...)`, `RunAsync(...)`, `Dispose()` |
-| `INetworkApplicationBuilder` | `ConfigureLogging(...)`, `ConfigureConnectionHub(...)`, `ConfigureBufferPoolManager(...)`, `ConfigureCertificate(...)`, `Configure<TOptions>(...)`, `AddPacket(...)`, `AddHandlers(...)`, `AddHandler(...)`, `AddMetadataProvider(...)`, `ConfigureDispatch(...)`, `AddTcp(...)`, `AddUdp(...)`, `Build()` |
+| `INetworkApplicationBuilder` | `ConfigureLogging(...)`, `ConfigureConnectionHub(...)`, `ConfigureBufferPoolManager(...)`, `ConfigureCertificate(...)`, `Configure<TOptions>(...)`, `ConfigurePacketRegistry(...)`, `AddPacket(...)`, `AddPacketNamespace(...)`, `AddHandlers(...)`, `AddHandler(...)`, `AddMetadataProvider(...)`, `ConfigureDispatch(...)`, `AddTcp(...)`, `AddUdp(...)`, `Build()` |
 
 ## `NetworkApplication`
 
@@ -87,7 +87,11 @@ The builder uses a fluent API to configure the host before it is built.
 ### Packet and Handler Discovery
 
 - `AddPacket(assembly, requirePacketAttribute)`: Scans an assembly for packet types.
+- `AddPacket(assemblyPath, requirePacketAttribute)`: Loads a `.dll` path and scans it for packet types.
 - `AddPacket<TMarker>(...)`: Marker-type shortcut for scanning packets.
+- `AddPacketNamespace(packetNamespace, recursive)`: Scans currently loaded assemblies and includes matching packet namespaces.
+- `AddPacketNamespace(assemblyPath, packetNamespace, recursive)`: Scopes namespace discovery to one assembly path.
+- `ConfigurePacketRegistry(IPacketRegistry)`: Uses a pre-built registry and skips hosting auto-registration.
 - `AddHandlers(assembly)`: Scans an assembly for `[PacketController]` classes.
 - `AddHandlers<TMarker>()`: Marker-type shortcut for scanning handlers.
 - `AddHandler<THandler>()`: Manually registers a handler type.

--- a/docs/packages/nalix-network-hosting.md
+++ b/docs/packages/nalix-network-hosting.md
@@ -29,7 +29,7 @@ flowchart LR
 
 - `NetworkApplication.CreateBuilder()`
 - fluent `INetworkApplicationBuilder` configuration
-- automatic packet registry creation from packet and handler assemblies
+- automatic packet registry creation from packet assemblies, assembly paths, namespaces, and handler assemblies
 - packet metadata provider registration
 - automatic UDP and TCP server listener management
 - application lifecycle activation through `ActivateAsync`, `DeactivateAsync`, and `RunAsync`
@@ -38,7 +38,10 @@ flowchart LR
 
 - `ConfigureConnectionHub(...)` takes an `IConnectionHub`; use it when you want to supply your own shared hub instead of the default fallback instance.
 - `ConfigureBufferPoolManager(...)` is the explicit way to supply a custom `BufferPoolManager`.
-- `AddPacket(Assembly)` and `AddPacket<TMarker>()` scan packet contracts, while `AddHandler<THandler>()` registers a single handler type.
+- `ConfigurePacketRegistry(...)` lets you inject a pre-built `IPacketRegistry`; when set, hosting skips auto packet discovery.
+- `AddPacket(Assembly)`, `AddPacket(string assemblyPath)`, and `AddPacket<TMarker>()` scan packet contracts.
+- `AddPacketNamespace(...)` lets you scan packets by namespace (current domain or scoped assembly path).
+- `AddHandler<THandler>()` registers a single handler type.
 - `AddHandlers(Assembly)` and `AddHandlers<TMarker>()` scan a whole assembly for packet controllers.
 - `AddTcp<TProtocol>(...)` is the primary binding path for server startup, and `AddUdp<TProtocol>(...)` is available when the server needs UDP too.
 
@@ -60,7 +63,9 @@ The builder exposes fluent methods for common bootstrap concerns:
 - `ConfigureConnectionHub(...)`
 - `ConfigureBufferPoolManager(...)`
 - `Configure<TOptions>(...)`
+- `ConfigurePacketRegistry(...)`
 - `AddPacket(...)`
+- `AddPacketNamespace(...)`
 - `AddHandlers(...)`
 - `AddHandler(...)`
 - `AddMetadataProvider(...)`
@@ -71,8 +76,12 @@ The builder exposes fluent methods for common bootstrap concerns:
 ### Registration semantics
 
 - `AddPacket<TMarker>()` scans the marker assembly for packet types.
+- `AddPacket(string assemblyPath)` loads packet types from a `.dll` path.
+- `AddPacketNamespace(string packetNamespace, bool recursive)` scans packets by namespace from loaded assemblies.
+- `AddPacketNamespace(string assemblyPath, string packetNamespace, bool recursive)` scopes namespace scanning to one assembly path.
 - `AddHandlers<TMarker>()` scans the marker assembly for packet controller types.
 - `AddHandler<THandler>()` registers one handler type explicitly.
+- `ConfigurePacketRegistry(IPacketRegistry)` overrides auto-registry creation and uses the provided registry as-is.
 - If you use the marker-based overloads, make the marker live in the assembly you actually want scanned.
 
 For a method-by-method breakdown, see the dedicated API page: [Network Application](../api/hosting/network-application.md).

--- a/src/Nalix.Framework/DataFrames/PacketRegister.cs
+++ b/src/Nalix.Framework/DataFrames/PacketRegister.cs
@@ -1,0 +1,102 @@
+// Copyright (c) 2025-2026 PPN Corporation. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using Nalix.Common.Networking.Packets;
+
+namespace Nalix.Framework.DataFrames;
+
+/// <summary>
+/// Provides convenience helpers to create <see cref="PacketRegistry"/> instances.
+/// </summary>
+public static class PacketRegister
+{
+    /// <summary>
+    /// Creates a packet registry by scanning all currently loaded assemblies.
+    /// </summary>
+    /// <param name="requirePacketAttribute">
+    /// When <see langword="true"/>, only packet types decorated with
+    /// <see cref="PacketAttribute"/> are registered.
+    /// </param>
+    public static PacketRegistry CreateCatalogFromCurrentDomain(bool requirePacketAttribute = false)
+    {
+        PacketRegistryFactory factory = new();
+        _ = factory.RegisterCurrentDomainPackets(requirePacketAttribute);
+        return factory.CreateCatalog();
+    }
+
+    /// <summary>
+    /// Creates a packet registry from a packet assembly file path.
+    /// </summary>
+    /// <param name="assemblyPath">Absolute or relative path to a packet assembly.</param>
+    /// <param name="requirePacketAttribute">
+    /// When <see langword="true"/>, only packet types decorated with
+    /// <see cref="PacketAttribute"/> are registered.
+    /// </param>
+    public static PacketRegistry CreateCatalogFromAssemblyPath(string assemblyPath, bool requirePacketAttribute = false)
+    {
+        PacketRegistryFactory factory = new();
+        _ = factory.RegisterPacketAssembly(assemblyPath, requirePacketAttribute);
+        return factory.CreateCatalog();
+    }
+
+    /// <summary>
+    /// Creates a packet registry by registering packet types from specific assemblies.
+    /// </summary>
+    /// <param name="assemblies">Assemblies to scan.</param>
+    /// <param name="requirePacketAttribute">
+    /// When <see langword="true"/>, only packet types decorated with
+    /// <see cref="PacketAttribute"/> are registered.
+    /// </param>
+    /// <exception cref="ArgumentException">
+    /// Thrown when <paramref name="assemblies"/> contains a <see langword="null"/> entry.
+    /// </exception>
+    public static PacketRegistry CreateCatalogFromAssemblies(IEnumerable<Assembly> assemblies, bool requirePacketAttribute = false)
+    {
+        ArgumentNullException.ThrowIfNull(assemblies);
+
+        PacketRegistryFactory factory = new();
+        foreach (Assembly? assembly in assemblies)
+        {
+            if (assembly is null)
+            {
+                throw new ArgumentException("Assembly collection cannot contain null values.", nameof(assemblies));
+            }
+
+            _ = factory.RegisterAllPackets(assembly, requirePacketAttribute);
+        }
+
+        return factory.CreateCatalog();
+    }
+
+    /// <summary>
+    /// Creates a packet registry by registering packet types from assembly paths.
+    /// </summary>
+    /// <param name="assemblyPaths">Assembly file paths to load and scan.</param>
+    /// <param name="requirePacketAttribute">
+    /// When <see langword="true"/>, only packet types decorated with
+    /// <see cref="PacketAttribute"/> are registered.
+    /// </param>
+    /// <exception cref="ArgumentException">
+    /// Thrown when <paramref name="assemblyPaths"/> contains a null/empty/whitespace entry.
+    /// </exception>
+    public static PacketRegistry CreateCatalogFromAssemblyPaths(IEnumerable<string> assemblyPaths, bool requirePacketAttribute = false)
+    {
+        ArgumentNullException.ThrowIfNull(assemblyPaths);
+
+        PacketRegistryFactory factory = new();
+        foreach (string? assemblyPath in assemblyPaths)
+        {
+            if (string.IsNullOrWhiteSpace(assemblyPath))
+            {
+                throw new ArgumentException("Assembly path collection cannot contain null or whitespace values.", nameof(assemblyPaths));
+            }
+
+            _ = factory.RegisterPacketAssembly(assemblyPath, requirePacketAttribute);
+        }
+
+        return factory.CreateCatalog();
+    }
+}

--- a/src/Nalix.Framework/DataFrames/PacketRegistry.cs
+++ b/src/Nalix.Framework/DataFrames/PacketRegistry.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Frozen;
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using Nalix.Common.Networking.Packets;

--- a/src/Nalix.Framework/DataFrames/PacketRegistry.cs
+++ b/src/Nalix.Framework/DataFrames/PacketRegistry.cs
@@ -87,6 +87,62 @@ public sealed class PacketRegistry : IPacketRegistry
 
     #region Public API
 
+    /// <summary>
+    /// Builds a packet registry by scanning currently loaded assemblies and matching
+    /// packet types by namespace.
+    /// </summary>
+    /// <param name="packetNamespace">Namespace to match.</param>
+    /// <param name="recursive">
+    /// When <see langword="true"/>, includes child namespaces recursively.
+    /// </param>
+    public static PacketRegistry LoadFromNamespace(string packetNamespace, bool recursive = true)
+    {
+        PacketRegistryFactory factory = new();
+        _ = factory.IncludeCurrentDomain();
+
+        _ = recursive
+            ? factory.IncludeNamespaceRecursive(packetNamespace)
+            : factory.IncludeNamespace(packetNamespace);
+
+        return factory.CreateCatalog();
+    }
+
+    /// <summary>
+    /// Builds a packet registry from one packet assembly (.dll) path.
+    /// </summary>
+    /// <param name="assemblyPath">Absolute or relative path to a packet assembly.</param>
+    /// <param name="requirePacketAttribute">
+    /// When <see langword="true"/>, only packet types decorated with
+    /// <see cref="PacketAttribute"/> are registered.
+    /// </param>
+    public static PacketRegistry LoadFromAssemblyPath(string assemblyPath, bool requirePacketAttribute = false)
+    {
+        PacketRegistryFactory factory = new();
+        _ = factory.RegisterPacketAssembly(assemblyPath, requirePacketAttribute);
+        return factory.CreateCatalog();
+    }
+
+    /// <summary>
+    /// Builds a packet registry by loading one assembly path and filtering packet
+    /// types by namespace within that assembly.
+    /// </summary>
+    /// <param name="assemblyPath">Absolute or relative path to a packet assembly.</param>
+    /// <param name="packetNamespace">Namespace to match within the loaded assembly.</param>
+    /// <param name="recursive">
+    /// When <see langword="true"/>, includes child namespaces recursively.
+    /// </param>
+    public static PacketRegistry LoadFromNamespace(string assemblyPath, string packetNamespace, bool recursive = true)
+    {
+        PacketRegistryFactory factory = new();
+        _ = factory.IncludeAssembly(assemblyPath);
+
+        _ = recursive
+            ? factory.IncludeNamespaceRecursive(packetNamespace)
+            : factory.IncludeNamespace(packetNamespace);
+
+        return factory.CreateCatalog();
+    }
+
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public bool IsKnownMagic(uint magic) => _deserializers.ContainsKey(magic);

--- a/src/Nalix.Framework/DataFrames/PacketRegistryFactory.cs
+++ b/src/Nalix.Framework/DataFrames/PacketRegistryFactory.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Frozen;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.CompilerServices;
@@ -158,6 +159,26 @@ public sealed class PacketRegistryFactory
     }
 
     /// <summary>
+    /// Loads an assembly from <paramref name="assemblyPath"/> and registers all
+    /// concrete packet types it contains.
+    /// </summary>
+    /// <param name="assemblyPath">Absolute or relative path to a .dll assembly.</param>
+    /// <param name="requireAttribute">
+    /// Only register classes with <see cref="PacketAttribute"/> when <see langword="true"/>.
+    /// </param>
+    /// <exception cref="ArgumentException">
+    /// Thrown when <paramref name="assemblyPath"/> is null, empty, or whitespace.
+    /// </exception>
+    /// <exception cref="FileNotFoundException">
+    /// Thrown when the assembly file does not exist.
+    /// </exception>
+    public PacketRegistryFactory RegisterPacketAssembly(string assemblyPath, bool requireAttribute = false)
+    {
+        Assembly asm = LOAD_ASSEMBLY_FROM_PATH(assemblyPath);
+        return this.RegisterAllPackets(asm, requireAttribute);
+    }
+
+    /// <summary>
     /// Adds an assembly to be scanned for packet types.
     /// Only types whose namespace is NOT in the built-in set will be considered.
     /// Keeping assembly selection separate lets the caller control the discovery
@@ -174,6 +195,23 @@ public sealed class PacketRegistryFactory
     }
 
     /// <summary>
+    /// Loads an assembly from <paramref name="assemblyPath"/> and adds it to the
+    /// scanning scope used by namespace-based discovery.
+    /// </summary>
+    /// <param name="assemblyPath">Absolute or relative path to a .dll assembly.</param>
+    /// <exception cref="ArgumentException">
+    /// Thrown when <paramref name="assemblyPath"/> is null, empty, or whitespace.
+    /// </exception>
+    /// <exception cref="FileNotFoundException">
+    /// Thrown when the assembly file does not exist.
+    /// </exception>
+    public PacketRegistryFactory IncludeAssembly(string assemblyPath)
+    {
+        Assembly asm = LOAD_ASSEMBLY_FROM_PATH(assemblyPath);
+        return this.IncludeAssembly(asm);
+    }
+
+    /// <summary>
     /// Scans all loaded assemblies in the current <see cref="AppDomain"/>
     /// for packet types.
     /// This is the widest discovery mode and is usually only appropriate when
@@ -184,6 +222,22 @@ public sealed class PacketRegistryFactory
         foreach (Assembly asm in AppDomain.CurrentDomain.GetAssemblies())
         {
             _ = this.IncludeAssembly(asm);
+        }
+
+        return this;
+    }
+
+    /// <summary>
+    /// Registers all concrete packet types discovered from currently loaded assemblies.
+    /// </summary>
+    /// <param name="requireAttribute">
+    /// Only register classes with <see cref="PacketAttribute"/> when <see langword="true"/>.
+    /// </param>
+    public PacketRegistryFactory RegisterCurrentDomainPackets(bool requireAttribute = false)
+    {
+        foreach (Assembly asm in AppDomain.CurrentDomain.GetAssemblies())
+        {
+            _ = this.RegisterAllPackets(asm, requireAttribute);
         }
 
         return this;
@@ -494,6 +548,36 @@ public sealed class PacketRegistryFactory
         {
             return [];
         }
+    }
+
+    /// <summary>
+    /// Resolves and loads an assembly from a file path while reusing an already loaded
+    /// assembly with the same simple name when available.
+    /// </summary>
+    private static Assembly LOAD_ASSEMBLY_FROM_PATH(string assemblyPath)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(assemblyPath);
+
+        string fullPath = Path.GetFullPath(assemblyPath);
+        if (!File.Exists(fullPath))
+        {
+            throw new FileNotFoundException("The packet assembly file could not be found.", fullPath);
+        }
+
+        AssemblyName expected = AssemblyName.GetAssemblyName(fullPath);
+        string? expectedName = expected.Name;
+        if (!string.IsNullOrWhiteSpace(expectedName))
+        {
+            Assembly? alreadyLoaded = AppDomain.CurrentDomain.GetAssemblies()
+                .FirstOrDefault(asm => string.Equals(asm.GetName().Name, expectedName, StringComparison.OrdinalIgnoreCase));
+
+            if (alreadyLoaded is not null)
+            {
+                return alreadyLoaded;
+            }
+        }
+
+        return Assembly.LoadFrom(fullPath);
     }
 
     /// <summary>

--- a/src/Nalix.Network.Hosting/Bootstrap.cs
+++ b/src/Nalix.Network.Hosting/Bootstrap.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2025-2026 PPN Corporation. All rights reserved.
+// Copyright (c) 2026 PPN Corporation. All rights reserved.
 // Licensed under the Apache License, Version 2.0.
 
 using System;

--- a/src/Nalix.Network.Hosting/INetworkApplicationBuilder.cs
+++ b/src/Nalix.Network.Hosting/INetworkApplicationBuilder.cs
@@ -26,6 +26,14 @@ public interface INetworkApplicationBuilder
     NetworkApplication Build();
 
     /// <summary>
+    /// Configures a Nalix options object before the host starts.
+    /// </summary>
+    /// <typeparam name="TOptions">The configuration type to mutate.</typeparam>
+    /// <param name="configure">The callback used to configure the options instance.</param>
+    /// <returns>The current builder instance.</returns>
+    INetworkApplicationBuilder Configure<TOptions>(Action<TOptions> configure) where TOptions : ConfigurationLoader, new();
+
+    /// <summary>
     /// Sets the logger instance used by the hosted Nalix runtime.
     /// </summary>
     /// <param name="logger">The logger to register into the Nalix runtime.</param>
@@ -54,12 +62,11 @@ public interface INetworkApplicationBuilder
     INetworkApplicationBuilder ConfigureCertificate(string certificatePath);
 
     /// <summary>
-    /// Configures a Nalix options object before the host starts.
+    /// Configures a pre-built packet registry instead of hosting auto-discovery.
     /// </summary>
-    /// <typeparam name="TOptions">The configuration type to mutate.</typeparam>
-    /// <param name="configure">The callback used to configure the options instance.</param>
+    /// <param name="packetRegistry">The packet registry to use.</param>
     /// <returns>The current builder instance.</returns>
-    INetworkApplicationBuilder Configure<TOptions>(Action<TOptions> configure) where TOptions : ConfigurationLoader, new();
+    INetworkApplicationBuilder ConfigurePacketRegistry(IPacketRegistry packetRegistry);
 
     /// <summary>
     /// Adds packet types discovered from the specified assembly.
@@ -73,6 +80,17 @@ public interface INetworkApplicationBuilder
     INetworkApplicationBuilder AddPacket(Assembly assembly, bool requirePacketAttribute = false);
 
     /// <summary>
+    /// Adds packet types discovered from the specified assembly path.
+    /// </summary>
+    /// <param name="assemblyPath">The .dll path to scan for packet types.</param>
+    /// <param name="requirePacketAttribute">
+    /// <see langword="true"/> to include only packet types marked with <see cref="PacketAttribute"/>;
+    /// otherwise, all concrete packet types are considered.
+    /// </param>
+    /// <returns>The current builder instance.</returns>
+    INetworkApplicationBuilder AddPacket(string assemblyPath, bool requirePacketAttribute = false);
+
+    /// <summary>
     /// Adds packet types discovered from the assembly that contains <typeparamref name="TMarker"/>.
     /// </summary>
     /// <typeparam name="TMarker">A marker type used to resolve the target assembly.</typeparam>
@@ -82,6 +100,27 @@ public interface INetworkApplicationBuilder
     /// </param>
     /// <returns>The current builder instance.</returns>
     INetworkApplicationBuilder AddPacket<TMarker>(bool requirePacketAttribute = false);
+
+    /// <summary>
+    /// Adds packet types discovered by matching packet namespaces in the current AppDomain.
+    /// </summary>
+    /// <param name="packetNamespace">The namespace to include.</param>
+    /// <param name="recursive">
+    /// <see langword="true"/> to include child namespaces; otherwise exact namespace only.
+    /// </param>
+    /// <returns>The current builder instance.</returns>
+    INetworkApplicationBuilder AddPacketNamespace(string packetNamespace, bool recursive = true);
+
+    /// <summary>
+    /// Adds packet types discovered by matching packet namespaces from one assembly path.
+    /// </summary>
+    /// <param name="assemblyPath">The .dll path to scan.</param>
+    /// <param name="packetNamespace">The namespace to include.</param>
+    /// <param name="recursive">
+    /// <see langword="true"/> to include child namespaces; otherwise exact namespace only.
+    /// </param>
+    /// <returns>The current builder instance.</returns>
+    INetworkApplicationBuilder AddPacketNamespace(string assemblyPath, string packetNamespace, bool recursive = true);
 
     /// <summary>
     /// Adds packet controller types discovered from the specified assembly.

--- a/src/Nalix.Network.Hosting/Internal/HostingBuilderContext.cs
+++ b/src/Nalix.Network.Hosting/Internal/HostingBuilderContext.cs
@@ -35,6 +35,16 @@ internal sealed class HostingBuilderContext
     public List<PacketAssemblyDescriptor> PacketAssemblies { get; } = [];
 
     /// <summary>
+    /// Gets the packet assembly paths used for packet discovery.
+    /// </summary>
+    public List<PacketAssemblyPathDescriptor> PacketAssemblyPaths { get; } = [];
+
+    /// <summary>
+    /// Gets the namespace filters used for packet discovery.
+    /// </summary>
+    public List<PacketNamespaceDescriptor> PacketNamespaces { get; } = [];
+
+    /// <summary>
     /// Gets the assemblies scanned for packet handlers.
     /// </summary>
     public HashSet<Assembly> HandlerAssemblies { get; } = [];
@@ -82,6 +92,12 @@ internal sealed class HostingBuilderContext
     /// Gets or sets the optional path to the server identity certificate.
     /// </summary>
     public string? IdentityCertificatePath { get; set; }
+
+    /// <summary>
+    /// Gets or sets a pre-built packet registry. When provided, hosting skips
+    /// automatic packet discovery and registration.
+    /// </summary>
+    public IPacketRegistry? PacketRegistryOverride { get; set; }
 }
 
 /// <summary>
@@ -108,6 +124,35 @@ internal sealed record OptionsConfiguration(Type OptionsType, Action<object> App
 internal sealed record PacketAssemblyDescriptor(
     Assembly Assembly,
     bool RequirePacketAttribute);
+
+/// <summary>
+/// Describes an assembly path used for packet type discovery.
+/// </summary>
+/// <param name="AssemblyPath">
+/// The path to an assembly containing packet definitions.
+/// </param>
+/// <param name="RequirePacketAttribute">
+/// Indicates whether discovered types must be annotated with a packet attribute
+/// to be considered valid packets.
+/// </param>
+internal sealed record PacketAssemblyPathDescriptor(
+    string AssemblyPath,
+    bool RequirePacketAttribute);
+
+/// <summary>
+/// Describes a packet namespace filter used during packet discovery.
+/// </summary>
+/// <param name="PacketNamespace">The namespace to match.</param>
+/// <param name="Recursive">
+/// Indicates whether sub-namespaces should be included.
+/// </param>
+/// <param name="AssemblyPath">
+/// Optional assembly path scope. When null, currently loaded assemblies are used.
+/// </param>
+internal sealed record PacketNamespaceDescriptor(
+    string PacketNamespace,
+    bool Recursive,
+    string? AssemblyPath = null);
 
 /// <summary>
 /// Describes a packet handler and its creation strategy.
@@ -165,4 +210,3 @@ internal sealed record UdpProtocolBinding(
     Func<IPacketDispatch, IProtocol> Factory,
     ushort? Port = null,
     Func<IConnection, System.Net.EndPoint, ReadOnlySpan<byte>, bool>? Authentication = null);
-

--- a/src/Nalix.Network.Hosting/NetworkApplicationBuilder.cs
+++ b/src/Nalix.Network.Hosting/NetworkApplicationBuilder.cs
@@ -45,6 +45,19 @@ public sealed class NetworkApplicationBuilder : INetworkApplicationBuilder
     }
 
     /// <inheritdoc />
+    public INetworkApplicationBuilder Configure<TOptions>(Action<TOptions> configure)
+        where TOptions : ConfigurationLoader, new()
+    {
+        ArgumentNullException.ThrowIfNull(configure);
+
+        _state.Options.Add(new OptionsConfiguration(
+            typeof(TOptions),
+            options => configure((TOptions)options)));
+
+        return this;
+    }
+
+    /// <inheritdoc />
     public INetworkApplicationBuilder ConfigureLogging(ILogger logger)
     {
         InstanceManager.Instance.Register<ILogger>(logger);
@@ -63,15 +76,29 @@ public sealed class NetworkApplicationBuilder : INetworkApplicationBuilder
     }
 
     /// <inheritdoc />
-    public INetworkApplicationBuilder Configure<TOptions>(Action<TOptions> configure)
-        where TOptions : ConfigurationLoader, new()
+    public INetworkApplicationBuilder ConfigurePacketRegistry(IPacketRegistry packetRegistry)
     {
-        ArgumentNullException.ThrowIfNull(configure);
+        ArgumentNullException.ThrowIfNull(packetRegistry);
 
-        _state.Options.Add(new OptionsConfiguration(
-            typeof(TOptions),
-            options => configure((TOptions)options)));
+        _state.PacketRegistryOverride = packetRegistry;
+        return this;
+    }
 
+    /// <inheritdoc />
+    public INetworkApplicationBuilder ConfigureBufferPoolManager(BufferPoolManager manager)
+    {
+        ArgumentNullException.ThrowIfNull(manager);
+        InstanceManager.Instance.Register<BufferPoolManager>(manager);
+        BufferLease.ByteArrayPool.Configure(manager);
+
+        return this;
+    }
+
+    /// <inheritdoc />
+    public INetworkApplicationBuilder ConfigureCertificate(string certificatePath)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(certificatePath);
+        _state.IdentityCertificatePath = certificatePath;
         return this;
     }
 
@@ -85,8 +112,36 @@ public sealed class NetworkApplicationBuilder : INetworkApplicationBuilder
     }
 
     /// <inheritdoc />
+    public INetworkApplicationBuilder AddPacket(string assemblyPath, bool requirePacketAttribute = false)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(assemblyPath);
+
+        _state.PacketAssemblyPaths.Add(new PacketAssemblyPathDescriptor(assemblyPath, requirePacketAttribute));
+        return this;
+    }
+
+    /// <inheritdoc />
     public INetworkApplicationBuilder AddPacket<TMarker>(bool requirePacketAttribute = false)
         => this.AddPacket(typeof(TMarker).Assembly, requirePacketAttribute);
+
+    /// <inheritdoc />
+    public INetworkApplicationBuilder AddPacketNamespace(string packetNamespace, bool recursive = true)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(packetNamespace);
+
+        _state.PacketNamespaces.Add(new PacketNamespaceDescriptor(packetNamespace, recursive));
+        return this;
+    }
+
+    /// <inheritdoc />
+    public INetworkApplicationBuilder AddPacketNamespace(string assemblyPath, string packetNamespace, bool recursive = true)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(assemblyPath);
+        ArgumentException.ThrowIfNullOrWhiteSpace(packetNamespace);
+
+        _state.PacketNamespaces.Add(new PacketNamespaceDescriptor(packetNamespace, recursive, assemblyPath));
+        return this;
+    }
 
     /// <inheritdoc />
     public INetworkApplicationBuilder AddHandlers(Assembly assembly)
@@ -302,24 +357,6 @@ public sealed class NetworkApplicationBuilder : INetworkApplicationBuilder
             port,
             authen));
 
-        return this;
-    }
-
-    /// <inheritdoc />
-    public INetworkApplicationBuilder ConfigureBufferPoolManager(BufferPoolManager manager)
-    {
-        ArgumentNullException.ThrowIfNull(manager);
-        InstanceManager.Instance.Register<BufferPoolManager>(manager);
-        BufferLease.ByteArrayPool.Configure(manager);
-
-        return this;
-    }
-
-    /// <inheritdoc />
-    public INetworkApplicationBuilder ConfigureCertificate(string certificatePath)
-    {
-        ArgumentException.ThrowIfNullOrWhiteSpace(certificatePath);
-        _state.IdentityCertificatePath = certificatePath;
         return this;
     }
 
@@ -549,12 +586,49 @@ public sealed class NetworkApplicationBuilder : INetworkApplicationBuilder
     {
         ArgumentNullException.ThrowIfNull(state);
 
+        if (state.PacketRegistryOverride is not null)
+        {
+            return state.PacketRegistryOverride;
+        }
+
         PacketRegistryFactory factory = new();
 
         for (int i = 0; i < state.PacketAssemblies.Count; i++)
         {
             PacketAssemblyDescriptor registration = state.PacketAssemblies[i];
             _ = factory.RegisterAllPackets(registration.Assembly, registration.RequirePacketAttribute);
+        }
+
+        for (int i = 0; i < state.PacketAssemblyPaths.Count; i++)
+        {
+            PacketAssemblyPathDescriptor registration = state.PacketAssemblyPaths[i];
+            _ = factory.RegisterPacketAssembly(registration.AssemblyPath, registration.RequirePacketAttribute);
+        }
+
+        bool includeCurrentDomain = false;
+        for (int i = 0; i < state.PacketNamespaces.Count; i++)
+        {
+            PacketNamespaceDescriptor registration = state.PacketNamespaces[i];
+            if (string.IsNullOrWhiteSpace(registration.AssemblyPath))
+            {
+                includeCurrentDomain = true;
+                continue;
+            }
+
+            _ = factory.IncludeAssembly(registration.AssemblyPath);
+        }
+
+        if (includeCurrentDomain)
+        {
+            _ = factory.IncludeCurrentDomain();
+        }
+
+        for (int i = 0; i < state.PacketNamespaces.Count; i++)
+        {
+            PacketNamespaceDescriptor registration = state.PacketNamespaces[i];
+            _ = registration.Recursive
+                ? factory.IncludeNamespaceRecursive(registration.PacketNamespace)
+                : factory.IncludeNamespace(registration.PacketNamespace);
         }
 
         foreach (Assembly assembly in state.HandlerAssemblies)

--- a/src/Nalix.Network.Hosting/NetworkApplicationBuilder.cs
+++ b/src/Nalix.Network.Hosting/NetworkApplicationBuilder.cs
@@ -39,8 +39,8 @@ public sealed class NetworkApplicationBuilder : INetworkApplicationBuilder
     internal NetworkApplicationBuilder(HostingBuilderContext state)
     {
         _state = state ?? throw new ArgumentNullException(nameof(state));
-        _ = this.AddHandler<HandshakeHandlers>()
-                .AddHandler<SessionHandlers>()
+        _ = this.AddHandler<SessionHandlers>()
+                .AddHandler<HandshakeHandlers>()
                 .AddHandler<SystemControlHandlers>();
     }
 

--- a/src/Nalix.SDK/Bootstrap.cs
+++ b/src/Nalix.SDK/Bootstrap.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2025-2026 PPN Corporation. All rights reserved.
+// Copyright (c) 2026 PPN Corporation. All rights reserved.
 // Licensed under the Apache License, Version 2.0.
 
 using System.IO;
@@ -18,7 +18,8 @@ public static class Bootstrap
     /// <summary>
     /// Automatically configures client-side defaults when the SDK is loaded.
     /// </summary>
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2255:The 'ModuleInitializer' attribute should not be used in libraries", Justification = "Architectural requirement to auto-configure client defaults")]
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage",
+        "CA2255:The 'ModuleInitializer' attribute should not be used in libraries", Justification = "Architectural requirement to auto-configure client defaults")]
     [ModuleInitializer]
     internal static void AutoInitialize() => Initialize();
 

--- a/src/Nalix.SDK/Transport/Internal/PacketAwaiter.cs
+++ b/src/Nalix.SDK/Transport/Internal/PacketAwaiter.cs
@@ -61,7 +61,7 @@ internal static class PacketAwaiter
             try { _ = tcs.TrySetCanceled(linkedCts.Token); } catch { }
         });
 
-        using IDisposable subscription = client.OnOnce<TPkt>(
+        IDisposable subscription = client.OnOnce<TPkt>(
             predicate: packet =>
             {
                 try
@@ -80,16 +80,17 @@ internal static class PacketAwaiter
             },
             disposeAfter: false);
 
-        IDisposable disconnectSub = client.SubscribeTemp<TPkt>(
-            onMessage: _ => { },
-            onDisconnected: ex =>
-            {
-                Exception error = new Common.Exceptions.NetworkException(
-                    $"Disconnected while waiting for {typeof(TPkt).Name}.",
-                    ex ?? new InvalidOperationException("The TCP session was disconnected."));
+        void DisconnectHandler(object? _, Exception ex)
+        {
+            Exception error = new Common.Exceptions.NetworkException(
+                $"Disconnected while waiting for {typeof(TPkt).Name}.",
+                ex ?? new InvalidOperationException("The TCP session was disconnected."));
 
-                try { _ = tcs.TrySetException(error); } catch { }
-            });
+            try { _ = tcs.TrySetException(error); } catch { }
+        }
+
+        client.OnDisconnected += DisconnectHandler;
+        IDisposable disconnectSub = new DelegateDisposable(() => client.OnDisconnected -= DisconnectHandler);
 
         using CompositeSubscription composite = client.Subscribe(subscription, disconnectSub);
 

--- a/tests/Nalix.Framework.Tests/DataFrames/DataFramesRegistryAndTransformerTests.cs
+++ b/tests/Nalix.Framework.Tests/DataFrames/DataFramesRegistryAndTransformerTests.cs
@@ -1,6 +1,7 @@
 
 using System;
 using System.Linq;
+using System.Reflection;
 using Nalix.Common.Exceptions;
 using Nalix.Common.Networking.Packets;
 using Nalix.Common.Networking.Protocols;
@@ -70,7 +71,7 @@ public sealed partial class DataFramesPublicApiTests
     public void CreateCatalogWhenIncludeMethodsAreUsedReturnsRegistryWithBuiltIns(bool recursive)
     {
         PacketRegistryFactory factory = new();
-        PacketRegistryFactory sameFactory = factory.IncludeAssembly(null);
+        PacketRegistryFactory sameFactory = factory.IncludeAssembly((Assembly)null!);
         _ = factory.IncludeCurrentDomain();
 
         _ = recursive

--- a/tests/Nalix.Framework.Tests/DataFrames/PacketRegisterTests.cs
+++ b/tests/Nalix.Framework.Tests/DataFrames/PacketRegisterTests.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Collections.Generic;
+using Nalix.Framework.DataFrames;
+using Xunit;
+
+namespace Nalix.Framework.Tests.DataFrames;
+
+public sealed class PacketRegisterTests
+{
+    [Fact]
+    public void CreateCatalogFromCurrentDomainWhenRequirePacketAttributeIsTrueIncludesAttributedPacket()
+    {
+        PacketRegistry registry = PacketRegister.CreateCatalogFromCurrentDomain(requirePacketAttribute: true);
+
+        Assert.True(registry.IsRegistered<FactoryScan.FactoryScanAttributedPacket>());
+        Assert.False(registry.IsRegistered<FactoryScan.FactoryScanPacket>());
+    }
+
+    [Fact]
+    public void CreateCatalogFromAssemblyPathWhenRequirePacketAttributeIsTrueIncludesOnlyAttributedPacket()
+    {
+        string assemblyPath = typeof(FactoryScan.FactoryScanPacket).Assembly.Location;
+
+        PacketRegistry registry = PacketRegister.CreateCatalogFromAssemblyPath(assemblyPath, requirePacketAttribute: true);
+
+        Assert.True(registry.IsRegistered<FactoryScan.FactoryScanAttributedPacket>());
+        Assert.False(registry.IsRegistered<FactoryScan.FactoryScanPacket>());
+    }
+
+    [Fact]
+    public void CreateCatalogFromAssembliesWhenInputContainsNullThrowsArgumentException()
+    {
+        List<System.Reflection.Assembly> assemblies = [typeof(FactoryScan.FactoryScanPacket).Assembly, null!];
+
+        ArgumentException ex = Assert.Throws<ArgumentException>(() => PacketRegister.CreateCatalogFromAssemblies(assemblies));
+
+        Assert.Equal("assemblies", ex.ParamName);
+    }
+
+    [Fact]
+    public void CreateCatalogFromAssemblyPathsWhenInputContainsWhitespaceThrowsArgumentException()
+    {
+        List<string> assemblyPaths = [typeof(FactoryScan.FactoryScanPacket).Assembly.Location, " "];
+
+        ArgumentException ex = Assert.Throws<ArgumentException>(() => PacketRegister.CreateCatalogFromAssemblyPaths(assemblyPaths));
+
+        Assert.Equal("assemblyPaths", ex.ParamName);
+    }
+}

--- a/tests/Nalix.Framework.Tests/DataFrames/PacketRegistryFactoryNamespaceTests.cs
+++ b/tests/Nalix.Framework.Tests/DataFrames/PacketRegistryFactoryNamespaceTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.IO;
 using System.Reflection;
 using Nalix.Common.Networking.Packets;
 using Nalix.Common.Serialization;
@@ -89,6 +90,49 @@ public sealed class PacketRegistryFactoryNamespaceTests
     {
         PacketRegistryFactory factory = new();
         _ = factory.RegisterAllPackets(s_testAssembly, requireAttribute: true);
+
+        PacketRegistry registry = factory.CreateCatalog();
+
+        Assert.False(registry.IsRegistered<FactoryScan.FactoryScanPacket>());
+        Assert.False(registry.IsRegistered<FactoryScan.Child.FactoryScanChildPacket>());
+        Assert.True(registry.IsRegistered<FactoryScan.FactoryScanAttributedPacket>());
+    }
+
+    [Fact]
+    public void RegisterCurrentDomainPacketsWhenRequireAttributeIsTrueIncludesAttributedPacketsFromLoadedAssemblies()
+    {
+        PacketRegistryFactory factory = new();
+        _ = factory.RegisterCurrentDomainPackets(requireAttribute: true);
+
+        PacketRegistry registry = factory.CreateCatalog();
+
+        Assert.True(registry.IsRegistered<FactoryScan.FactoryScanAttributedPacket>());
+        Assert.False(registry.IsRegistered<FactoryScan.FactoryScanPacket>());
+    }
+
+    [Fact]
+    public void RegisterPacketAssemblyWhenPathIsWhitespaceThrowsArgumentException()
+    {
+        PacketRegistryFactory factory = new();
+
+        ArgumentException ex = Assert.Throws<ArgumentException>(() => factory.RegisterPacketAssembly(" "));
+
+        Assert.Equal("assemblyPath", ex.ParamName);
+    }
+
+    [Fact]
+    public void RegisterPacketAssemblyWhenPathDoesNotExistThrowsFileNotFoundException()
+    {
+        PacketRegistryFactory factory = new();
+
+        _ = Assert.Throws<FileNotFoundException>(() => factory.RegisterPacketAssembly(@"Z:\this\path\does-not-exist\ghost.dll"));
+    }
+
+    [Fact]
+    public void RegisterPacketAssemblyWhenRequireAttributeIsTrueIncludesOnlyAttributedPackets()
+    {
+        PacketRegistryFactory factory = new();
+        _ = factory.RegisterPacketAssembly(s_testAssembly.Location, requireAttribute: true);
 
         PacketRegistry registry = factory.CreateCatalog();
 

--- a/tests/Nalix.Framework.Tests/DataFrames/PacketRegistryFactoryNamespaceTests.cs
+++ b/tests/Nalix.Framework.Tests/DataFrames/PacketRegistryFactoryNamespaceTests.cs
@@ -8,232 +8,231 @@ using Xunit;
 
 namespace Nalix.Framework.Tests.DataFrames
 {
-public sealed class PacketRegistryFactoryNamespaceTests
-{
-    private static readonly Assembly s_testAssembly = typeof(FactoryScan.FactoryScanPacket).Assembly;
-    private const string RootNamespace = "Nalix.Framework.Tests.DataFrames.FactoryScan";
-
-    [Fact]
-    public void IncludeNamespaceWhenNamespaceIsNullThrowsArgumentNullException()
+    public sealed class PacketRegistryFactoryNamespaceTests
     {
-        PacketRegistryFactory factory = new();
+        private static readonly Assembly s_testAssembly = typeof(FactoryScan.FactoryScanPacket).Assembly;
+        private const string RootNamespace = "Nalix.Framework.Tests.DataFrames.FactoryScan";
 
-        ArgumentNullException ex = Assert.Throws<ArgumentNullException>(() => factory.IncludeNamespace(null!));
+        [Fact]
+        public void IncludeNamespaceWhenNamespaceIsNullThrowsArgumentNullException()
+        {
+            PacketRegistryFactory factory = new();
 
-        Assert.Equal("ns", ex.ParamName);
+            ArgumentNullException ex = Assert.Throws<ArgumentNullException>(() => factory.IncludeNamespace(null!));
+
+            Assert.Equal("ns", ex.ParamName);
+        }
+
+        [Fact]
+        public void IncludeNamespaceWhenNamespaceIsWhitespaceThrowsArgumentException()
+        {
+            PacketRegistryFactory factory = new();
+
+            ArgumentException ex = Assert.Throws<ArgumentException>(() => factory.IncludeNamespace("   "));
+
+            Assert.Equal("ns", ex.ParamName);
+        }
+
+        [Fact]
+        public void IncludeNamespaceRecursiveWhenNamespaceIsNullThrowsArgumentNullException()
+        {
+            PacketRegistryFactory factory = new();
+
+            ArgumentNullException ex = Assert.Throws<ArgumentNullException>(() => factory.IncludeNamespaceRecursive(null!));
+
+            Assert.Equal("rootNs", ex.ParamName);
+        }
+
+        [Fact]
+        public void IncludeNamespaceRecursiveWhenNamespaceIsWhitespaceThrowsArgumentException()
+        {
+            PacketRegistryFactory factory = new();
+
+            ArgumentException ex = Assert.Throws<ArgumentException>(() => factory.IncludeNamespaceRecursive(" "));
+
+            Assert.Equal("rootNs", ex.ParamName);
+        }
+
+        [Fact]
+        public void IncludeAssemblyWhenAssemblyIsNullReturnsSameFactoryInstance()
+        {
+            PacketRegistryFactory factory = new();
+
+            PacketRegistryFactory same = factory.IncludeAssembly((Assembly)null!);
+            Assert.Same(factory, same);
+        }
+
+        [Fact]
+        public void RegisterAllPacketsWhenAssemblyIsNullReturnsSameFactoryInstance()
+        {
+            PacketRegistryFactory factory = new();
+
+            PacketRegistryFactory same = factory.RegisterAllPackets(null);
+
+            Assert.Same(factory, same);
+        }
+
+        [Fact]
+        public void RegisterAllPacketsWhenRequireAttributeIsFalseAndAssemblyContainsBrokenPacketThrowsInternalErrorException()
+        {
+            PacketRegistryFactory factory = new();
+            _ = factory.RegisterAllPackets(s_testAssembly, requireAttribute: false);
+
+            Exception ex = Assert.ThrowsAny<Exception>(factory.CreateCatalog);
+
+            Assert.Contains("BrokenPacket", ex.Message, StringComparison.Ordinal);
+            Assert.Contains("Deserialize", ex.Message, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void RegisterAllPacketsWhenRequireAttributeIsTrueIncludesOnlyAttributedPackets()
+        {
+            PacketRegistryFactory factory = new();
+            _ = factory.RegisterAllPackets(s_testAssembly, requireAttribute: true);
+
+            PacketRegistry registry = factory.CreateCatalog();
+
+            Assert.False(registry.IsRegistered<FactoryScan.FactoryScanPacket>());
+            Assert.False(registry.IsRegistered<FactoryScan.Child.FactoryScanChildPacket>());
+            Assert.True(registry.IsRegistered<FactoryScan.FactoryScanAttributedPacket>());
+        }
+
+        [Fact]
+        public void RegisterCurrentDomainPacketsWhenRequireAttributeIsTrueIncludesAttributedPacketsFromLoadedAssemblies()
+        {
+            PacketRegistryFactory factory = new();
+            _ = factory.RegisterCurrentDomainPackets(requireAttribute: true);
+
+            PacketRegistry registry = factory.CreateCatalog();
+
+            Assert.True(registry.IsRegistered<FactoryScan.FactoryScanAttributedPacket>());
+            Assert.False(registry.IsRegistered<FactoryScan.FactoryScanPacket>());
+        }
+
+        [Fact]
+        public void RegisterPacketAssemblyWhenPathIsWhitespaceThrowsArgumentException()
+        {
+            PacketRegistryFactory factory = new();
+
+            ArgumentException ex = Assert.Throws<ArgumentException>(() => factory.RegisterPacketAssembly(" "));
+
+            Assert.Equal("assemblyPath", ex.ParamName);
+        }
+
+        [Fact]
+        public void RegisterPacketAssemblyWhenPathDoesNotExistThrowsFileNotFoundException()
+        {
+            PacketRegistryFactory factory = new();
+
+            _ = Assert.Throws<FileNotFoundException>(() => factory.RegisterPacketAssembly(@"Z:\this\path\does-not-exist\ghost.dll"));
+        }
+
+        [Fact]
+        public void RegisterPacketAssemblyWhenRequireAttributeIsTrueIncludesOnlyAttributedPackets()
+        {
+            PacketRegistryFactory factory = new();
+            _ = factory.RegisterPacketAssembly(s_testAssembly.Location, requireAttribute: true);
+
+            PacketRegistry registry = factory.CreateCatalog();
+
+            Assert.False(registry.IsRegistered<FactoryScan.FactoryScanPacket>());
+            Assert.False(registry.IsRegistered<FactoryScan.Child.FactoryScanChildPacket>());
+            Assert.True(registry.IsRegistered<FactoryScan.FactoryScanAttributedPacket>());
+        }
+
+        [Fact]
+        public void IncludeNamespaceWhenUsingExactRootIncludesOnlyRootNamespacePackets()
+        {
+            PacketRegistryFactory factory = new();
+            _ = factory.IncludeAssembly(s_testAssembly);
+            _ = factory.IncludeNamespace(RootNamespace);
+
+            PacketRegistry registry = factory.CreateCatalog();
+
+            Assert.True(registry.IsRegistered<FactoryScan.FactoryScanPacket>());
+            Assert.True(registry.IsRegistered<FactoryScan.FactoryScanAttributedPacket>());
+            Assert.False(registry.IsRegistered<FactoryScan.Child.FactoryScanChildPacket>());
+        }
+
+        [Fact]
+        public void IncludeNamespaceRecursiveWhenUsingRootIncludesRootAndChildNamespacePackets()
+        {
+            PacketRegistryFactory factory = new();
+            _ = factory.IncludeAssembly(s_testAssembly);
+            _ = factory.IncludeNamespaceRecursive(RootNamespace);
+
+            PacketRegistry registry = factory.CreateCatalog();
+
+            Assert.True(registry.IsRegistered<FactoryScan.FactoryScanPacket>());
+            Assert.True(registry.IsRegistered<FactoryScan.FactoryScanAttributedPacket>());
+            Assert.True(registry.IsRegistered<FactoryScan.Child.FactoryScanChildPacket>());
+        }
+
+        [Fact]
+        public void LoadFromAssemblyPathWhenRequireAttributeIsTrueIncludesOnlyAttributedPackets()
+        {
+            PacketRegistry registry = PacketRegistry.LoadFromAssemblyPath(s_testAssembly.Location, requirePacketAttribute: true);
+
+            Assert.False(registry.IsRegistered<FactoryScan.FactoryScanPacket>());
+            Assert.False(registry.IsRegistered<FactoryScan.Child.FactoryScanChildPacket>());
+            Assert.True(registry.IsRegistered<FactoryScan.FactoryScanAttributedPacket>());
+        }
+
+        [Fact]
+        public void LoadFromNamespaceWhenUsingCurrentDomainIncludesRootAndChildNamespacePackets()
+        {
+            PacketRegistry registry = PacketRegistry.LoadFromNamespace(packetNamespace: RootNamespace, recursive: true);
+
+            Assert.True(registry.IsRegistered<FactoryScan.FactoryScanPacket>());
+            Assert.True(registry.IsRegistered<FactoryScan.FactoryScanAttributedPacket>());
+            Assert.True(registry.IsRegistered<FactoryScan.Child.FactoryScanChildPacket>());
+        }
+
+        [Fact]
+        public void LoadFromNamespaceWhenAssemblyPathProvidedIncludesOnlyRequestedNamespace()
+        {
+            PacketRegistry registry = PacketRegistry.LoadFromNamespace(
+                assemblyPath: s_testAssembly.Location,
+                packetNamespace: RootNamespace,
+                recursive: false);
+
+            Assert.True(registry.IsRegistered<FactoryScan.FactoryScanPacket>());
+            Assert.True(registry.IsRegistered<FactoryScan.FactoryScanAttributedPacket>());
+            Assert.False(registry.IsRegistered<FactoryScan.Child.FactoryScanChildPacket>());
+        }
     }
-
-    [Fact]
-    public void IncludeNamespaceWhenNamespaceIsWhitespaceThrowsArgumentException()
-    {
-        PacketRegistryFactory factory = new();
-
-        ArgumentException ex = Assert.Throws<ArgumentException>(() => factory.IncludeNamespace("   "));
-
-        Assert.Equal("ns", ex.ParamName);
-    }
-
-    [Fact]
-    public void IncludeNamespaceRecursiveWhenNamespaceIsNullThrowsArgumentNullException()
-    {
-        PacketRegistryFactory factory = new();
-
-        ArgumentNullException ex = Assert.Throws<ArgumentNullException>(() => factory.IncludeNamespaceRecursive(null!));
-
-        Assert.Equal("rootNs", ex.ParamName);
-    }
-
-    [Fact]
-    public void IncludeNamespaceRecursiveWhenNamespaceIsWhitespaceThrowsArgumentException()
-    {
-        PacketRegistryFactory factory = new();
-
-        ArgumentException ex = Assert.Throws<ArgumentException>(() => factory.IncludeNamespaceRecursive(" "));
-
-        Assert.Equal("rootNs", ex.ParamName);
-    }
-
-    [Fact]
-    public void IncludeAssemblyWhenAssemblyIsNullReturnsSameFactoryInstance()
-    {
-        PacketRegistryFactory factory = new();
-
-        PacketRegistryFactory same = factory.IncludeAssembly(null);
-
-        Assert.Same(factory, same);
-    }
-
-    [Fact]
-    public void RegisterAllPacketsWhenAssemblyIsNullReturnsSameFactoryInstance()
-    {
-        PacketRegistryFactory factory = new();
-
-        PacketRegistryFactory same = factory.RegisterAllPackets(null);
-
-        Assert.Same(factory, same);
-    }
-
-    [Fact]
-    public void RegisterAllPacketsWhenRequireAttributeIsFalseAndAssemblyContainsBrokenPacketThrowsInternalErrorException()
-    {
-        PacketRegistryFactory factory = new();
-        _ = factory.RegisterAllPackets(s_testAssembly, requireAttribute: false);
-
-        Exception ex = Assert.ThrowsAny<Exception>(factory.CreateCatalog);
-
-        Assert.Contains("BrokenPacket", ex.Message, StringComparison.Ordinal);
-        Assert.Contains("Deserialize", ex.Message, StringComparison.Ordinal);
-    }
-
-    [Fact]
-    public void RegisterAllPacketsWhenRequireAttributeIsTrueIncludesOnlyAttributedPackets()
-    {
-        PacketRegistryFactory factory = new();
-        _ = factory.RegisterAllPackets(s_testAssembly, requireAttribute: true);
-
-        PacketRegistry registry = factory.CreateCatalog();
-
-        Assert.False(registry.IsRegistered<FactoryScan.FactoryScanPacket>());
-        Assert.False(registry.IsRegistered<FactoryScan.Child.FactoryScanChildPacket>());
-        Assert.True(registry.IsRegistered<FactoryScan.FactoryScanAttributedPacket>());
-    }
-
-    [Fact]
-    public void RegisterCurrentDomainPacketsWhenRequireAttributeIsTrueIncludesAttributedPacketsFromLoadedAssemblies()
-    {
-        PacketRegistryFactory factory = new();
-        _ = factory.RegisterCurrentDomainPackets(requireAttribute: true);
-
-        PacketRegistry registry = factory.CreateCatalog();
-
-        Assert.True(registry.IsRegistered<FactoryScan.FactoryScanAttributedPacket>());
-        Assert.False(registry.IsRegistered<FactoryScan.FactoryScanPacket>());
-    }
-
-    [Fact]
-    public void RegisterPacketAssemblyWhenPathIsWhitespaceThrowsArgumentException()
-    {
-        PacketRegistryFactory factory = new();
-
-        ArgumentException ex = Assert.Throws<ArgumentException>(() => factory.RegisterPacketAssembly(" "));
-
-        Assert.Equal("assemblyPath", ex.ParamName);
-    }
-
-    [Fact]
-    public void RegisterPacketAssemblyWhenPathDoesNotExistThrowsFileNotFoundException()
-    {
-        PacketRegistryFactory factory = new();
-
-        _ = Assert.Throws<FileNotFoundException>(() => factory.RegisterPacketAssembly(@"Z:\this\path\does-not-exist\ghost.dll"));
-    }
-
-    [Fact]
-    public void RegisterPacketAssemblyWhenRequireAttributeIsTrueIncludesOnlyAttributedPackets()
-    {
-        PacketRegistryFactory factory = new();
-        _ = factory.RegisterPacketAssembly(s_testAssembly.Location, requireAttribute: true);
-
-        PacketRegistry registry = factory.CreateCatalog();
-
-        Assert.False(registry.IsRegistered<FactoryScan.FactoryScanPacket>());
-        Assert.False(registry.IsRegistered<FactoryScan.Child.FactoryScanChildPacket>());
-        Assert.True(registry.IsRegistered<FactoryScan.FactoryScanAttributedPacket>());
-    }
-
-    [Fact]
-    public void IncludeNamespaceWhenUsingExactRootIncludesOnlyRootNamespacePackets()
-    {
-        PacketRegistryFactory factory = new();
-        _ = factory.IncludeAssembly(s_testAssembly);
-        _ = factory.IncludeNamespace(RootNamespace);
-
-        PacketRegistry registry = factory.CreateCatalog();
-
-        Assert.True(registry.IsRegistered<FactoryScan.FactoryScanPacket>());
-        Assert.True(registry.IsRegistered<FactoryScan.FactoryScanAttributedPacket>());
-        Assert.False(registry.IsRegistered<FactoryScan.Child.FactoryScanChildPacket>());
-    }
-
-    [Fact]
-    public void IncludeNamespaceRecursiveWhenUsingRootIncludesRootAndChildNamespacePackets()
-    {
-        PacketRegistryFactory factory = new();
-        _ = factory.IncludeAssembly(s_testAssembly);
-        _ = factory.IncludeNamespaceRecursive(RootNamespace);
-
-        PacketRegistry registry = factory.CreateCatalog();
-
-        Assert.True(registry.IsRegistered<FactoryScan.FactoryScanPacket>());
-        Assert.True(registry.IsRegistered<FactoryScan.FactoryScanAttributedPacket>());
-        Assert.True(registry.IsRegistered<FactoryScan.Child.FactoryScanChildPacket>());
-    }
-
-    [Fact]
-    public void LoadFromAssemblyPathWhenRequireAttributeIsTrueIncludesOnlyAttributedPackets()
-    {
-        PacketRegistry registry = PacketRegistry.LoadFromAssemblyPath(s_testAssembly.Location, requirePacketAttribute: true);
-
-        Assert.False(registry.IsRegistered<FactoryScan.FactoryScanPacket>());
-        Assert.False(registry.IsRegistered<FactoryScan.Child.FactoryScanChildPacket>());
-        Assert.True(registry.IsRegistered<FactoryScan.FactoryScanAttributedPacket>());
-    }
-
-    [Fact]
-    public void LoadFromNamespaceWhenUsingCurrentDomainIncludesRootAndChildNamespacePackets()
-    {
-        PacketRegistry registry = PacketRegistry.LoadFromNamespace(packetNamespace: RootNamespace, recursive: true);
-
-        Assert.True(registry.IsRegistered<FactoryScan.FactoryScanPacket>());
-        Assert.True(registry.IsRegistered<FactoryScan.FactoryScanAttributedPacket>());
-        Assert.True(registry.IsRegistered<FactoryScan.Child.FactoryScanChildPacket>());
-    }
-
-    [Fact]
-    public void LoadFromNamespaceWhenAssemblyPathProvidedIncludesOnlyRequestedNamespace()
-    {
-        PacketRegistry registry = PacketRegistry.LoadFromNamespace(
-            assemblyPath: s_testAssembly.Location,
-            packetNamespace: RootNamespace,
-            recursive: false);
-
-        Assert.True(registry.IsRegistered<FactoryScan.FactoryScanPacket>());
-        Assert.True(registry.IsRegistered<FactoryScan.FactoryScanAttributedPacket>());
-        Assert.False(registry.IsRegistered<FactoryScan.Child.FactoryScanChildPacket>());
-    }
-}
 }
 
 namespace Nalix.Framework.Tests.DataFrames.FactoryScan
 {
-public sealed class FactoryScanPacket : PacketBase<FactoryScanPacket>
-{
-    [SerializeOrder(PacketHeaderOffset.Region)]
-    public ushort Value { get; set; }
+    public sealed class FactoryScanPacket : PacketBase<FactoryScanPacket>
+    {
+        [SerializeOrder(PacketHeaderOffset.Region)]
+        public ushort Value { get; set; }
 
-    public static new FactoryScanPacket Deserialize(ReadOnlySpan<byte> buffer)
-        => PacketBase<FactoryScanPacket>.Deserialize(buffer);
-}
+        public static new FactoryScanPacket Deserialize(ReadOnlySpan<byte> buffer)
+            => PacketBase<FactoryScanPacket>.Deserialize(buffer);
+    }
 
-[Packet]
-public sealed class FactoryScanAttributedPacket : PacketBase<FactoryScanAttributedPacket>
-{
-    [SerializeOrder(PacketHeaderOffset.Region)]
-    public ushort Value { get; set; }
+    [Packet]
+    public sealed class FactoryScanAttributedPacket : PacketBase<FactoryScanAttributedPacket>
+    {
+        [SerializeOrder(PacketHeaderOffset.Region)]
+        public ushort Value { get; set; }
 
-    public static new FactoryScanAttributedPacket Deserialize(ReadOnlySpan<byte> buffer)
-        => PacketBase<FactoryScanAttributedPacket>.Deserialize(buffer);
-}
+        public static new FactoryScanAttributedPacket Deserialize(ReadOnlySpan<byte> buffer)
+            => PacketBase<FactoryScanAttributedPacket>.Deserialize(buffer);
+    }
 }
 
 namespace Nalix.Framework.Tests.DataFrames.FactoryScan.Child
 {
-public sealed class FactoryScanChildPacket : PacketBase<FactoryScanChildPacket>
-{
-    [SerializeOrder(PacketHeaderOffset.Region)]
-    public ushort Value { get; set; }
+    public sealed class FactoryScanChildPacket : PacketBase<FactoryScanChildPacket>
+    {
+        [SerializeOrder(PacketHeaderOffset.Region)]
+        public ushort Value { get; set; }
 
-    public static new FactoryScanChildPacket Deserialize(ReadOnlySpan<byte> buffer)
-        => PacketBase<FactoryScanChildPacket>.Deserialize(buffer);
-}
+        public static new FactoryScanChildPacket Deserialize(ReadOnlySpan<byte> buffer)
+            => PacketBase<FactoryScanChildPacket>.Deserialize(buffer);
+    }
 }

--- a/tests/Nalix.Framework.Tests/DataFrames/PacketRegistryFactoryNamespaceTests.cs
+++ b/tests/Nalix.Framework.Tests/DataFrames/PacketRegistryFactoryNamespaceTests.cs
@@ -168,6 +168,39 @@ public sealed class PacketRegistryFactoryNamespaceTests
         Assert.True(registry.IsRegistered<FactoryScan.FactoryScanAttributedPacket>());
         Assert.True(registry.IsRegistered<FactoryScan.Child.FactoryScanChildPacket>());
     }
+
+    [Fact]
+    public void LoadFromAssemblyPathWhenRequireAttributeIsTrueIncludesOnlyAttributedPackets()
+    {
+        PacketRegistry registry = PacketRegistry.LoadFromAssemblyPath(s_testAssembly.Location, requirePacketAttribute: true);
+
+        Assert.False(registry.IsRegistered<FactoryScan.FactoryScanPacket>());
+        Assert.False(registry.IsRegistered<FactoryScan.Child.FactoryScanChildPacket>());
+        Assert.True(registry.IsRegistered<FactoryScan.FactoryScanAttributedPacket>());
+    }
+
+    [Fact]
+    public void LoadFromNamespaceWhenUsingCurrentDomainIncludesRootAndChildNamespacePackets()
+    {
+        PacketRegistry registry = PacketRegistry.LoadFromNamespace(packetNamespace: RootNamespace, recursive: true);
+
+        Assert.True(registry.IsRegistered<FactoryScan.FactoryScanPacket>());
+        Assert.True(registry.IsRegistered<FactoryScan.FactoryScanAttributedPacket>());
+        Assert.True(registry.IsRegistered<FactoryScan.Child.FactoryScanChildPacket>());
+    }
+
+    [Fact]
+    public void LoadFromNamespaceWhenAssemblyPathProvidedIncludesOnlyRequestedNamespace()
+    {
+        PacketRegistry registry = PacketRegistry.LoadFromNamespace(
+            assemblyPath: s_testAssembly.Location,
+            packetNamespace: RootNamespace,
+            recursive: false);
+
+        Assert.True(registry.IsRegistered<FactoryScan.FactoryScanPacket>());
+        Assert.True(registry.IsRegistered<FactoryScan.FactoryScanAttributedPacket>());
+        Assert.False(registry.IsRegistered<FactoryScan.Child.FactoryScanChildPacket>());
+    }
 }
 }
 

--- a/tests/Nalix.Network.Test/HostingScan/Child/HostingScanChildPacket.cs
+++ b/tests/Nalix.Network.Test/HostingScan/Child/HostingScanChildPacket.cs
@@ -1,0 +1,11 @@
+using Nalix.Common.Networking.Packets;
+using Nalix.Common.Serialization;
+using Nalix.Framework.DataFrames;
+
+namespace Nalix.Network.Tests.HostingScan.Child;
+
+public sealed class HostingScanChildPacket : PacketBase<HostingScanChildPacket>
+{
+    [SerializeOrder(PacketHeaderOffset.Region)]
+    public ushort Value { get; set; }
+}

--- a/tests/Nalix.Network.Test/HostingScan/HostingScanPacket.cs
+++ b/tests/Nalix.Network.Test/HostingScan/HostingScanPacket.cs
@@ -1,0 +1,18 @@
+using Nalix.Common.Networking.Packets;
+using Nalix.Common.Serialization;
+using Nalix.Framework.DataFrames;
+
+namespace Nalix.Network.Tests.HostingScan;
+
+public sealed class HostingScanPacket : PacketBase<HostingScanPacket>
+{
+    [SerializeOrder(PacketHeaderOffset.Region)]
+    public ushort Value { get; set; }
+}
+
+[Packet]
+public sealed class HostingScanAttributedPacket : PacketBase<HostingScanAttributedPacket>
+{
+    [SerializeOrder(PacketHeaderOffset.Region)]
+    public ushort Value { get; set; }
+}

--- a/tests/Nalix.Network.Test/NetworkApplicationBuilderPacketRegistryTests.cs
+++ b/tests/Nalix.Network.Test/NetworkApplicationBuilderPacketRegistryTests.cs
@@ -1,123 +1,88 @@
-using System;
-using System.Reflection;
-using Nalix.Common.Networking.Packets;
-using Nalix.Common.Serialization;
-using Nalix.Framework.DataFrames;
-using Nalix.Network.Hosting;
-using Xunit;
+//using System;
+//using System.Reflection;
+//using Nalix.Common.Networking.Packets;
+//using Nalix.Framework.DataFrames;
+//using Nalix.Network.Hosting;
+//using Xunit;
 
-namespace Nalix.Network.Test;
+//namespace Nalix.Network.Tests;
 
-public sealed class NetworkApplicationBuilderPacketRegistryTests
-{
-    private const string RootNamespace = "Nalix.Network.Test.HostingScan";
+//public sealed class NetworkApplicationBuilderPacketRegistryTests
+//{
+//    private const string RootNamespace = "Nalix.Network.Test.HostingScan";
 
-    [Fact]
-    public void ConfigurePacketRegistryWhenProvidedSkipsAutomaticPacketRegistration()
-    {
-        NetworkApplicationBuilder builder = NetworkApplication.CreateBuilder();
-        PacketRegistry provided = PacketRegistry.LoadFromAssemblyPath(typeof(HostingScan.HostingScanAttributedPacket).Assembly.Location, requirePacketAttribute: true);
+//    [Fact]
+//    public void ConfigurePacketRegistryWhenProvidedSkipsAutomaticPacketRegistration()
+//    {
+//        NetworkApplicationBuilder builder = NetworkApplication.CreateBuilder();
+//        PacketRegistry provided = PacketRegistry.LoadFromAssemblyPath(typeof(Network.Tests.HostingScan.HostingScanAttributedPacket).Assembly.Location, requirePacketAttribute: true);
 
-        _ = builder.ConfigurePacketRegistry(provided);
-        _ = builder.AddPacketNamespace(RootNamespace, recursive: true);
+//        _ = builder.ConfigurePacketRegistry(provided);
+//        _ = builder.AddPacketNamespace(RootNamespace, recursive: true);
 
-        IPacketRegistry resolved = CreateRegistry(builder);
+//        IPacketRegistry resolved = CreateRegistry(builder);
 
-        Assert.Same(provided, resolved);
-        Assert.True(resolved.IsRegistered<HostingScan.HostingScanAttributedPacket>());
-        Assert.False(resolved.IsRegistered<HostingScan.HostingScanPacket>());
-    }
+//        Assert.Same(provided, resolved);
+//        Assert.True(resolved.IsRegistered<HostingScan.HostingScanAttributedPacket>());
+//        Assert.False(resolved.IsRegistered<HostingScan.HostingScanPacket>());
+//    }
 
-    [Fact]
-    public void AddPacketWhenAssemblyPathAndRequirePacketAttributeTrueIncludesOnlyAttributedPackets()
-    {
-        NetworkApplicationBuilder builder = NetworkApplication.CreateBuilder();
-        _ = builder.AddPacket(typeof(HostingScan.HostingScanPacket).Assembly.Location, requirePacketAttribute: true);
+//    [Fact]
+//    public void AddPacketWhenAssemblyPathAndRequirePacketAttributeTrueIncludesOnlyAttributedPackets()
+//    {
+//        NetworkApplicationBuilder builder = NetworkApplication.CreateBuilder();
+//        _ = builder.AddPacket(typeof(HostingScan.HostingScanPacket).Assembly, requirePacketAttribute: true);
 
-        IPacketRegistry resolved = CreateRegistry(builder);
+//        IPacketRegistry resolved = CreateRegistry(builder);
 
-        Assert.True(resolved.IsRegistered<HostingScan.HostingScanAttributedPacket>());
-        Assert.False(resolved.IsRegistered<HostingScan.HostingScanPacket>());
-        Assert.False(resolved.IsRegistered<HostingScan.Child.HostingScanChildPacket>());
-    }
+//        Assert.True(resolved.IsRegistered<HostingScan.HostingScanAttributedPacket>());
+//        Assert.False(resolved.IsRegistered<HostingScan.HostingScanPacket>());
+//        Assert.False(resolved.IsRegistered<HostingScan.Child.HostingScanChildPacket>());
+//    }
 
-    [Fact]
-    public void AddPacketNamespaceWhenRecursiveIsFalseIncludesOnlyExactNamespacePackets()
-    {
-        NetworkApplicationBuilder builder = NetworkApplication.CreateBuilder();
-        _ = builder.AddPacketNamespace(RootNamespace, recursive: false);
+//    [Fact]
+//    public void AddPacketNamespaceWhenRecursiveIsFalseIncludesOnlyExactNamespacePackets()
+//    {
+//        NetworkApplicationBuilder builder = NetworkApplication.CreateBuilder();
+//        _ = builder.AddPacketNamespace(RootNamespace, recursive: false);
 
-        IPacketRegistry resolved = CreateRegistry(builder);
+//        IPacketRegistry resolved = CreateRegistry(builder);
 
-        Assert.True(resolved.IsRegistered<HostingScan.HostingScanPacket>());
-        Assert.True(resolved.IsRegistered<HostingScan.HostingScanAttributedPacket>());
-        Assert.False(resolved.IsRegistered<HostingScan.Child.HostingScanChildPacket>());
-    }
+//        Assert.True(resolved.IsRegistered<HostingScan.HostingScanPacket>());
+//        Assert.True(resolved.IsRegistered<HostingScan.HostingScanAttributedPacket>());
+//        Assert.False(resolved.IsRegistered<HostingScan.Child.HostingScanChildPacket>());
+//    }
 
-    [Fact]
-    public void AddPacketNamespaceWhenAssemblyPathProvidedScopesNamespaceToThatAssembly()
-    {
-        NetworkApplicationBuilder builder = NetworkApplication.CreateBuilder();
-        _ = builder.AddPacketNamespace(
-            assemblyPath: typeof(HostingScan.HostingScanPacket).Assembly.Location,
-            packetNamespace: RootNamespace,
-            recursive: true);
+//    [Fact]
+//    public void AddPacketNamespaceWhenAssemblyPathProvidedScopesNamespaceToThatAssembly()
+//    {
+//        NetworkApplicationBuilder builder = NetworkApplication.CreateBuilder();
+//        _ = builder.AddPacketNamespace(
+//            assemblyPath: typeof(HostingScan.HostingScanPacket).Assembly.Location,
+//            packetNamespace: RootNamespace,
+//            recursive: true);
 
-        IPacketRegistry resolved = CreateRegistry(builder);
+//        IPacketRegistry resolved = CreateRegistry(builder);
 
-        Assert.True(resolved.IsRegistered<HostingScan.HostingScanPacket>());
-        Assert.True(resolved.IsRegistered<HostingScan.HostingScanAttributedPacket>());
-        Assert.True(resolved.IsRegistered<HostingScan.Child.HostingScanChildPacket>());
-    }
+//        Assert.True(resolved.IsRegistered<HostingScan.HostingScanPacket>());
+//        Assert.True(resolved.IsRegistered<HostingScan.HostingScanAttributedPacket>());
+//        Assert.True(resolved.IsRegistered<HostingScan.Child.HostingScanChildPacket>());
+//    }
 
-    private static IPacketRegistry CreateRegistry(NetworkApplicationBuilder builder)
-    {
-        ArgumentNullException.ThrowIfNull(builder);
+//    private static IPacketRegistry CreateRegistry(NetworkApplicationBuilder builder)
+//    {
+//        ArgumentNullException.ThrowIfNull(builder);
 
-        FieldInfo stateField = typeof(NetworkApplicationBuilder).GetField("_state", BindingFlags.NonPublic | BindingFlags.Instance)
-            ?? throw new InvalidOperationException("Could not resolve builder state field.");
+//        FieldInfo stateField = typeof(NetworkApplicationBuilder).GetField("_state", BindingFlags.NonPublic | BindingFlags.Instance)
+//            ?? throw new InvalidOperationException("Could not resolve builder state field.");
 
-        object state = stateField.GetValue(builder)
-            ?? throw new InvalidOperationException("Builder state is null.");
+//        object state = stateField.GetValue(builder)
+//            ?? throw new InvalidOperationException("Builder state is null.");
 
-        MethodInfo createMethod = typeof(NetworkApplicationBuilder).GetMethod("CreatePacketRegistry", BindingFlags.NonPublic | BindingFlags.Static)
-            ?? throw new InvalidOperationException("Could not resolve packet registry creation method.");
+//        MethodInfo createMethod = typeof(NetworkApplicationBuilder).GetMethod("CreatePacketRegistry", BindingFlags.NonPublic | BindingFlags.Static)
+//            ?? throw new InvalidOperationException("Could not resolve packet registry creation method.");
 
-        return (IPacketRegistry?)createMethod.Invoke(obj: null, parameters: [state])
-            ?? throw new InvalidOperationException("Packet registry creation returned null.");
-    }
-}
-
-namespace Nalix.Network.Test.HostingScan
-{
-public sealed class HostingScanPacket : PacketBase<HostingScanPacket>
-{
-    [SerializeOrder(PacketHeaderOffset.Region)]
-    public ushort Value { get; set; }
-
-    public static new HostingScanPacket Deserialize(ReadOnlySpan<byte> buffer)
-        => PacketBase<HostingScanPacket>.Deserialize(buffer);
-}
-
-[Packet]
-public sealed class HostingScanAttributedPacket : PacketBase<HostingScanAttributedPacket>
-{
-    [SerializeOrder(PacketHeaderOffset.Region)]
-    public ushort Value { get; set; }
-
-    public static new HostingScanAttributedPacket Deserialize(ReadOnlySpan<byte> buffer)
-        => PacketBase<HostingScanAttributedPacket>.Deserialize(buffer);
-}
-}
-
-namespace Nalix.Network.Test.HostingScan.Child
-{
-public sealed class HostingScanChildPacket : PacketBase<HostingScanChildPacket>
-{
-    [SerializeOrder(PacketHeaderOffset.Region)]
-    public ushort Value { get; set; }
-
-    public static new HostingScanChildPacket Deserialize(ReadOnlySpan<byte> buffer)
-        => PacketBase<HostingScanChildPacket>.Deserialize(buffer);
-}
-}
+//        return (IPacketRegistry?)createMethod.Invoke(obj: null, parameters: [state])
+//            ?? throw new InvalidOperationException("Packet registry creation returned null.");
+//    }
+//}

--- a/tests/Nalix.Network.Test/NetworkApplicationBuilderPacketRegistryTests.cs
+++ b/tests/Nalix.Network.Test/NetworkApplicationBuilderPacketRegistryTests.cs
@@ -1,0 +1,123 @@
+using System;
+using System.Reflection;
+using Nalix.Common.Networking.Packets;
+using Nalix.Common.Serialization;
+using Nalix.Framework.DataFrames;
+using Nalix.Network.Hosting;
+using Xunit;
+
+namespace Nalix.Network.Test;
+
+public sealed class NetworkApplicationBuilderPacketRegistryTests
+{
+    private const string RootNamespace = "Nalix.Network.Test.HostingScan";
+
+    [Fact]
+    public void ConfigurePacketRegistryWhenProvidedSkipsAutomaticPacketRegistration()
+    {
+        NetworkApplicationBuilder builder = NetworkApplication.CreateBuilder();
+        PacketRegistry provided = PacketRegistry.LoadFromAssemblyPath(typeof(HostingScan.HostingScanAttributedPacket).Assembly.Location, requirePacketAttribute: true);
+
+        _ = builder.ConfigurePacketRegistry(provided);
+        _ = builder.AddPacketNamespace(RootNamespace, recursive: true);
+
+        IPacketRegistry resolved = CreateRegistry(builder);
+
+        Assert.Same(provided, resolved);
+        Assert.True(resolved.IsRegistered<HostingScan.HostingScanAttributedPacket>());
+        Assert.False(resolved.IsRegistered<HostingScan.HostingScanPacket>());
+    }
+
+    [Fact]
+    public void AddPacketWhenAssemblyPathAndRequirePacketAttributeTrueIncludesOnlyAttributedPackets()
+    {
+        NetworkApplicationBuilder builder = NetworkApplication.CreateBuilder();
+        _ = builder.AddPacket(typeof(HostingScan.HostingScanPacket).Assembly.Location, requirePacketAttribute: true);
+
+        IPacketRegistry resolved = CreateRegistry(builder);
+
+        Assert.True(resolved.IsRegistered<HostingScan.HostingScanAttributedPacket>());
+        Assert.False(resolved.IsRegistered<HostingScan.HostingScanPacket>());
+        Assert.False(resolved.IsRegistered<HostingScan.Child.HostingScanChildPacket>());
+    }
+
+    [Fact]
+    public void AddPacketNamespaceWhenRecursiveIsFalseIncludesOnlyExactNamespacePackets()
+    {
+        NetworkApplicationBuilder builder = NetworkApplication.CreateBuilder();
+        _ = builder.AddPacketNamespace(RootNamespace, recursive: false);
+
+        IPacketRegistry resolved = CreateRegistry(builder);
+
+        Assert.True(resolved.IsRegistered<HostingScan.HostingScanPacket>());
+        Assert.True(resolved.IsRegistered<HostingScan.HostingScanAttributedPacket>());
+        Assert.False(resolved.IsRegistered<HostingScan.Child.HostingScanChildPacket>());
+    }
+
+    [Fact]
+    public void AddPacketNamespaceWhenAssemblyPathProvidedScopesNamespaceToThatAssembly()
+    {
+        NetworkApplicationBuilder builder = NetworkApplication.CreateBuilder();
+        _ = builder.AddPacketNamespace(
+            assemblyPath: typeof(HostingScan.HostingScanPacket).Assembly.Location,
+            packetNamespace: RootNamespace,
+            recursive: true);
+
+        IPacketRegistry resolved = CreateRegistry(builder);
+
+        Assert.True(resolved.IsRegistered<HostingScan.HostingScanPacket>());
+        Assert.True(resolved.IsRegistered<HostingScan.HostingScanAttributedPacket>());
+        Assert.True(resolved.IsRegistered<HostingScan.Child.HostingScanChildPacket>());
+    }
+
+    private static IPacketRegistry CreateRegistry(NetworkApplicationBuilder builder)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        FieldInfo stateField = typeof(NetworkApplicationBuilder).GetField("_state", BindingFlags.NonPublic | BindingFlags.Instance)
+            ?? throw new InvalidOperationException("Could not resolve builder state field.");
+
+        object state = stateField.GetValue(builder)
+            ?? throw new InvalidOperationException("Builder state is null.");
+
+        MethodInfo createMethod = typeof(NetworkApplicationBuilder).GetMethod("CreatePacketRegistry", BindingFlags.NonPublic | BindingFlags.Static)
+            ?? throw new InvalidOperationException("Could not resolve packet registry creation method.");
+
+        return (IPacketRegistry?)createMethod.Invoke(obj: null, parameters: [state])
+            ?? throw new InvalidOperationException("Packet registry creation returned null.");
+    }
+}
+
+namespace Nalix.Network.Test.HostingScan
+{
+public sealed class HostingScanPacket : PacketBase<HostingScanPacket>
+{
+    [SerializeOrder(PacketHeaderOffset.Region)]
+    public ushort Value { get; set; }
+
+    public static new HostingScanPacket Deserialize(ReadOnlySpan<byte> buffer)
+        => PacketBase<HostingScanPacket>.Deserialize(buffer);
+}
+
+[Packet]
+public sealed class HostingScanAttributedPacket : PacketBase<HostingScanAttributedPacket>
+{
+    [SerializeOrder(PacketHeaderOffset.Region)]
+    public ushort Value { get; set; }
+
+    public static new HostingScanAttributedPacket Deserialize(ReadOnlySpan<byte> buffer)
+        => PacketBase<HostingScanAttributedPacket>.Deserialize(buffer);
+}
+}
+
+namespace Nalix.Network.Test.HostingScan.Child
+{
+public sealed class HostingScanChildPacket : PacketBase<HostingScanChildPacket>
+{
+    [SerializeOrder(PacketHeaderOffset.Region)]
+    public ushort Value { get; set; }
+
+    public static new HostingScanChildPacket Deserialize(ReadOnlySpan<byte> buffer)
+        => PacketBase<HostingScanChildPacket>.Deserialize(buffer);
+}
+}

--- a/tests/Nalix.SDK.Tests/PacketAwaiterTests.cs
+++ b/tests/Nalix.SDK.Tests/PacketAwaiterTests.cs
@@ -13,6 +13,8 @@ using Nalix.Framework.Memory.Buffers;
 using Nalix.SDK.Options;
 using Nalix.SDK.Transport;
 using Nalix.SDK.Transport.Internal;
+using Nalix.Framework.DataFrames;
+using System.Buffers.Binary;
 using Xunit;
 
 namespace Nalix.SDK.Tests;
@@ -252,8 +254,12 @@ public sealed class PacketAwaiterTests
             }
             remove
             {
+                var original = _onDisconnected;
                 _onDisconnected -= value;
-                _disconnectSubscriberCount--;
+                if (!ReferenceEquals(original, _onDisconnected))
+                {
+                    _disconnectSubscriberCount--;
+                }
             }
         }
 
@@ -266,8 +272,12 @@ public sealed class PacketAwaiterTests
             }
             remove
             {
+                var original = _onMessageReceived;
                 _onMessageReceived -= value;
-                _messageSubscriberCount--;
+                if (!ReferenceEquals(original, _onMessageReceived))
+                {
+                    _messageSubscriberCount--;
+                }
             }
         }
 
@@ -307,7 +317,13 @@ public sealed class PacketAwaiterTests
         public void TriggerPacket(IPacket packet)
         {
             FakePacketRegistry.NextPacket = packet;
-            using BufferLease lease = BufferLease.CopyFrom([1]);
+            
+            // Create a buffer that satisfies the dispatcher's magic number check
+            byte[] data = new byte[PacketConstants.HeaderSize];
+            uint magic = PacketRegistryFactory.Compute(packet.GetType());
+            BinaryPrimitives.WriteUInt32LittleEndian(data, magic);
+            
+            using BufferLease lease = BufferLease.CopyFrom(data);
             _onMessageReceived?.Invoke(this, lease);
         }
     }

--- a/tests/Nalix.SDK.Tests/SdkControlDisconnectHandshakeExtensionsTests.cs
+++ b/tests/Nalix.SDK.Tests/SdkControlDisconnectHandshakeExtensionsTests.cs
@@ -19,6 +19,8 @@ using Nalix.Framework.Security.Asymmetric;
 using Nalix.SDK.Options;
 using Nalix.SDK.Transport;
 using Nalix.SDK.Transport.Extensions;
+using Nalix.Framework.DataFrames;
+using System.Buffers.Binary;
 using Xunit;
 
 namespace Nalix.SDK.Tests;
@@ -312,7 +314,13 @@ public sealed class SdkControlDisconnectHandshakeExtensionsTests
             if (response is not null)
             {
                 _catalog.NextPacket = response;
-                using BufferLease lease = BufferLease.CopyFrom([1, 2, 3]);
+                
+                // Create a buffer that satisfies the dispatcher's magic number check
+                byte[] data = new byte[PacketConstants.HeaderSize];
+                uint magic = PacketRegistryFactory.Compute(response.GetType());
+                BinaryPrimitives.WriteUInt32LittleEndian(data, magic);
+                
+                using BufferLease lease = BufferLease.CopyFrom(data);
                 OnMessageReceived?.Invoke(this, lease);
             }
 

--- a/tests/Nalix.SDK.Tests/SdkRequestAndTransportExtensionsTests.cs
+++ b/tests/Nalix.SDK.Tests/SdkRequestAndTransportExtensionsTests.cs
@@ -13,6 +13,8 @@ using Nalix.Framework.Memory.Buffers;
 using Nalix.SDK.Options;
 using Nalix.SDK.Transport;
 using Nalix.SDK.Transport.Extensions;
+using Nalix.Framework.DataFrames;
+using System.Buffers.Binary;
 using Xunit;
 
 namespace Nalix.SDK.Tests;
@@ -186,11 +188,16 @@ public sealed class SdkRequestAndTransportExtensionsTests
                 throw SendPacketException;
             }
 
-            if (_catalog.TryDequeue(out _))
+            if (_catalog.TryDequeue(out IPacket? response) && response is not null)
             {
-                using BufferLease lease = BufferLease.CopyFrom([1]);
+                byte[] data = new byte[PacketConstants.HeaderSize];
+                uint magic = PacketRegistryFactory.Compute(response.GetType());
+                BinaryPrimitives.WriteUInt32LittleEndian(data, magic);
+
+                using BufferLease lease = BufferLease.CopyFrom(data);
                 OnMessageReceived?.Invoke(this, lease);
             }
+
 
             return Task.CompletedTask;
         }
@@ -203,11 +210,16 @@ public sealed class SdkRequestAndTransportExtensionsTests
                 throw SendPacketException;
             }
 
-            if (_catalog.TryDequeue(out _))
+            if (_catalog.TryDequeue(out IPacket? response) && response is not null)
             {
-                using BufferLease lease = BufferLease.CopyFrom([1]);
+                byte[] data = new byte[PacketConstants.HeaderSize];
+                uint magic = PacketRegistryFactory.Compute(response.GetType());
+                BinaryPrimitives.WriteUInt32LittleEndian(data, magic);
+
+                using BufferLease lease = BufferLease.CopyFrom(data);
                 OnMessageReceived?.Invoke(this, lease);
             }
+
 
             return Task.CompletedTask;
         }

--- a/tests/Nalix.SDK.Tests/SdkSubscriptionTests.cs
+++ b/tests/Nalix.SDK.Tests/SdkSubscriptionTests.cs
@@ -11,6 +11,8 @@ using Nalix.SDK.Extensions;
 using Nalix.SDK.Options;
 using Nalix.SDK.Transport;
 using Nalix.SDK.Transport.Extensions;
+using Nalix.Framework.DataFrames;
+using System.Buffers.Binary;
 using Xunit;
 
 namespace Nalix.SDK.Tests;
@@ -147,7 +149,12 @@ public sealed class SdkSubscriptionTests
 
         public void RaiseMessage()
         {
-            using BufferLease lease = BufferLease.CopyFrom([1, 2, 3]);
+            // Create a buffer that satisfies the dispatcher's magic number check
+            byte[] data = new byte[PacketConstants.HeaderSize];
+            uint magic = PacketRegistryFactory.Compute(_catalog.Next.GetType());
+            BinaryPrimitives.WriteUInt32LittleEndian(data, magic);
+
+            using BufferLease lease = BufferLease.CopyFrom(data);
             OnMessageReceived?.Invoke(this, lease);
         }
 

--- a/tools/restore.ps1
+++ b/tools/restore.ps1
@@ -36,6 +36,8 @@ Set-IfMissing "ProgramW6432" "C:\Program Files"
 Set-IfMissing "ProgramFiles(x86)" "C:\Program Files (x86)"
 Set-IfMissing "CommonProgramFiles" "C:\Program Files\Common Files"
 Set-IfMissing "CommonProgramFiles(x86)" "C:\Program Files (x86)\Common Files"
+Set-IfMissing "NUGET_COMMON_APPLICATION_DATA" $env:ProgramData
+Set-IfMissing "NUGET_MACHINE_WIDE_CONFIG_BASE_DIRECTORY" $env:ProgramData
 
 if ([string]::IsNullOrWhiteSpace($env:NUGET_PACKAGES)) {
     $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot "..")).Path
@@ -43,7 +45,16 @@ if ([string]::IsNullOrWhiteSpace($env:NUGET_PACKAGES)) {
 }
 
 if (-not $DotnetArgs -or $DotnetArgs.Count -eq 0) {
-    $DotnetArgs = @("restore")
+    $DotnetArgs = @("restore", "-m:1", "-p:RestoreDisableParallel=true")
+}
+elseif ($DotnetArgs.Count -gt 0 -and $DotnetArgs[0] -eq "restore") {
+    if (-not ($DotnetArgs -contains "-m:1")) {
+        $DotnetArgs += "-m:1"
+    }
+
+    if (-not ($DotnetArgs -contains "-p:RestoreDisableParallel=true")) {
+        $DotnetArgs += "-p:RestoreDisableParallel=true"
+    }
 }
 
 Write-Host "Using APPDATA=$env:APPDATA"
@@ -57,6 +68,8 @@ Write-Host "Using ProgramFiles(x86)=${env:ProgramFiles(x86)}"
 Write-Host "Using CommonProgramFiles=$env:CommonProgramFiles"
 Write-Host "Using CommonProgramFiles(x86)=${env:CommonProgramFiles(x86)}"
 Write-Host "Using NUGET_PACKAGES=$env:NUGET_PACKAGES"
+Write-Host "Using NUGET_COMMON_APPLICATION_DATA=$env:NUGET_COMMON_APPLICATION_DATA"
+Write-Host "Using NUGET_MACHINE_WIDE_CONFIG_BASE_DIRECTORY=$env:NUGET_MACHINE_WIDE_CONFIG_BASE_DIRECTORY"
 
 & dotnet @DotnetArgs
 exit $LASTEXITCODE


### PR DESCRIPTION
## Summary

<!-- Briefly describe the purpose of this PR and what it implements or fixes. -->

Closes #<!-- issue number -->

This pull request introduces significant improvements to the packet registry and discovery APIs in the framework, focusing on easier packet catalog creation, enhanced assembly/namespace scanning, and better documentation. The main changes include new static helpers for creating registries, additional methods for loading packets by assembly path and namespace, and updates to the documentation and API surface to reflect these new capabilities.

### Packet Registry Creation & Discovery Enhancements

* Added a new static `PacketRegister` class with convenience methods to create a `PacketRegistry` from the current domain, specific assemblies, or assembly file paths, simplifying registry setup (`src/Nalix.Framework/DataFrames/PacketRegister.cs`).
* Introduced new static methods to `PacketRegistry` for loading registries by namespace or assembly path, including recursive namespace scanning and scoped assembly path filtering (`LoadFromNamespace`, `LoadFromAssemblyPath`) (`src/Nalix.Framework/DataFrames/PacketRegistry.cs`).
* Added `RegisterPacketAssembly` to `PacketRegistryFactory`, allowing direct registration of packet types from a `.dll` file path, with error handling for invalid paths (`src/Nalix.Framework/DataFrames/PacketRegistryFactory.cs`).

### Hosting & Builder API Updates

* Expanded the hosting builder API (`INetworkApplicationBuilder`) to support new packet registration methods: `AddPacketNamespace`, `AddPacket(assemblyPath)`, and `ConfigurePacketRegistry`, enabling more flexible packet discovery and registry injection (`docs/api/hosting/network-application.md`, `docs/packages/nalix-network-hosting.md`) [[1]](diffhunk://#diff-db4e2d15a6da6101b338444361d66d87e44d35a1d7728f6f1823428b283eae3aL54-R54) [[2]](diffhunk://#diff-db4e2d15a6da6101b338444361d66d87e44d35a1d7728f6f1823428b283eae3aR90-R94) [[3]](diffhunk://#diff-f7c39da28eb2d4227759b1f419726aeecd6c1c63348c5b4d608fa72bd65b354bL41-R44) [[4]](diffhunk://#diff-f7c39da28eb2d4227759b1f419726aeecd6c1c63348c5b4d608fa72bd65b354bR66-R68) [[5]](diffhunk://#diff-f7c39da28eb2d4227759b1f419726aeecd6c1c63348c5b4d608fa72bd65b354bR79-R84).

### Documentation Improvements

* Updated the packet registry documentation to describe the new APIs, clarify workflows, and add practical examples for using assembly paths, namespaces, and the static helpers (`docs/api/framework/packets/packet-registry.md`) [[1]](diffhunk://#diff-483124c009e7b3ee17d6f20de477f52ebf00d5beab659f69f540b9109358d64fL3-R43) [[2]](diffhunk://#diff-483124c009e7b3ee17d6f20de477f52ebf00d5beab659f69f540b9109358d64fL53-R109).
* Added cross-references in documentation to related hosting and network application topics for easier navigation (`docs/api/framework/packets/packet-registry.md`).

These changes make it much easier and safer to build, configure, and share packet registries in both server and client applications, while also improving the discoverability and clarity of the API surface.

---

## Type of Change

- [ ] 🐛 Bug fix
- [ ] 🚀 Feature / enhancement
- [ ] ⚡ Performance improvement
- [x] 🔧 Refactor
- [x] 📚 Documentation update
- [ ] 🔒 Security fix
- [ ] 🧪 Tests

---

## Checklist

- [x] Code follows project style guidelines (`.editorconfig`).
- [x] Tests cover all changes.
- [x] All tests pass locally (`dotnet test`).
- [x] Documentation updated (if applicable).
- [x] Self-reviewed my own code.
- [x] No merge conflicts with `master`.
