### PR TITLE
refactor: PacketSender to non-generic

### DIFF
--- a/src/Nalix.Analyzers/Analyzers/NalixUsageAnalyzer.cs
+++ b/src/Nalix.Analyzers/Analyzers/NalixUsageAnalyzer.cs
@@ -307,7 +307,6 @@ public sealed partial class NalixUsageAnalyzer : DiagnosticAnalyzer
 
         bool isExplicitLayout = IsExplicitSerializeLayout(serializePackable, symbols.SerializeLayoutType);
         bool isPacketBaseType = InheritsPacketBase(typeSymbol, symbols);
-        List<(ISymbol Member, int Order)> orderedMembers = [];
         List<(ISymbol Member, int Order)> serializeOrderedMembers = [];
 
         List<ISymbol> allMembers = [];
@@ -347,7 +346,6 @@ public sealed partial class NalixUsageAnalyzer : DiagnosticAnalyzer
 
             if (finalOrder.HasValue)
             {
-                orderedMembers.Add((member, finalOrder.Value));
                 if (order.HasValue)
                 {
                     serializeOrderedMembers.Add((member, order.Value));
@@ -376,7 +374,7 @@ public sealed partial class NalixUsageAnalyzer : DiagnosticAnalyzer
             }
         }
 
-        foreach (IGrouping<int, (ISymbol Member, int Order)> duplicateGroup in orderedMembers.GroupBy(static x => x.Order).Where(static g => g.Count() > 1))
+        foreach (IGrouping<int, (ISymbol Member, int Order)> duplicateGroup in serializeOrderedMembers.GroupBy(static x => x.Order).Where(static g => g.Count() > 1))
         {
             foreach ((ISymbol member, _) in duplicateGroup)
             {

--- a/src/Nalix.Common/Networking/Packets/IPacketContext.cs
+++ b/src/Nalix.Common/Networking/Packets/IPacketContext.cs
@@ -48,7 +48,7 @@ public interface IPacketContext<TPacket> : IPoolable where TPacket : IPacket
     /// based on the current handler's attributes.
     /// Use this instead of calling connection.TCP.SendAsync() directly.
     /// </summary>
-    IPacketSender<TPacket> Sender { get; }
+    IPacketSender Sender { get; }
 
     /// <summary>
     /// Gets or sets the cancellation token associated with the packet context.

--- a/src/Nalix.Common/Networking/Packets/IPacketSender.cs
+++ b/src/Nalix.Common/Networking/Packets/IPacketSender.cs
@@ -10,11 +10,10 @@ namespace Nalix.Common.Networking.Packets;
 /// <summary>
 /// Abstracts packet sending with automatic transform (encrypt/compress)
 /// </summary>
-/// <typeparam name="TPacket"></typeparam>
-public interface IPacketSender<TPacket> : IPoolable where TPacket : IPacket
+public interface IPacketSender : IPoolable
 {
     /// <inheritdoc/>
-    void Initialize(IPacketContext<TPacket> context);
+    void Initialize<TPacket>(IPacketContext<TPacket> context) where TPacket : IPacket;
 
     /// <summary>
     /// Sends a packet, applying encryption/compression automatically
@@ -26,7 +25,7 @@ public interface IPacketSender<TPacket> : IPoolable where TPacket : IPacket
     /// <param name="ct">
     /// A cancellation token that can cancel the send operation.
     /// </param>
-    ValueTask SendAsync(TPacket packet, CancellationToken ct = default);
+    ValueTask SendAsync(IPacket packet, CancellationToken ct = default);
 
     /// <summary>
     /// Sends a packet, explicitly overriding the encryption flag.
@@ -40,5 +39,5 @@ public interface IPacketSender<TPacket> : IPoolable where TPacket : IPacket
     /// <param name="ct">
     /// A cancellation token that can cancel the send operation.
     /// </param>
-    ValueTask SendAsync(TPacket packet, bool forceEncrypt, CancellationToken ct = default);
+    ValueTask SendAsync(IPacket packet, bool forceEncrypt, CancellationToken ct = default);
 }

--- a/src/Nalix.Framework/DataFrames/PacketRegistryFactory.cs
+++ b/src/Nalix.Framework/DataFrames/PacketRegistryFactory.cs
@@ -246,7 +246,7 @@ public sealed class PacketRegistryFactory
     /// <summary>
     /// Registers all concrete <see cref="IPacket"/> types whose namespace exactly matches
     /// <paramref name="ns"/>, from all assemblies that have been added via
-    /// <see cref="IncludeAssembly"/> or <see cref="IncludeCurrentDomain"/>.
+    /// <see cref="IncludeAssembly(Assembly)"/> or <see cref="IncludeCurrentDomain"/>.
     /// </summary>
     /// <param name="ns">
     /// The exact namespace to match, e.g. <c>"MyGame.Network.Packets"</c>.
@@ -273,7 +273,7 @@ public sealed class PacketRegistryFactory
     /// <summary>
     /// Registers all concrete <see cref="IPacket"/> types whose namespace is exactly
     /// <paramref name="rootNs"/> <b>or starts with <c>"{rootNs}."</c></b>, from all
-    /// assemblies that have been added via <see cref="IncludeAssembly"/> or
+    /// assemblies that have been added via <see cref="IncludeAssembly(Assembly)"/> or
     /// <see cref="IncludeCurrentDomain"/>.
     /// </summary>
     /// <param name="rootNs">

--- a/src/Nalix.Runtime/Dispatching/PacketContext.cs
+++ b/src/Nalix.Runtime/Dispatching/PacketContext.cs
@@ -76,7 +76,7 @@ public sealed class PacketContext<TPacket> : IPacketContext<TPacket>, IPoolable,
     }
 
     /// <inheritdoc/>
-    public IPacketSender<TPacket> Sender
+    public IPacketSender Sender
     {
         [MethodImpl(MethodImplOptions.AggressiveOptimization)]
         get;
@@ -128,7 +128,7 @@ public sealed class PacketContext<TPacket> : IPacketContext<TPacket>, IPoolable,
     {
         _state = (int)PacketContextState.Pooled;
 
-        this.Sender = new PacketSender<TPacket>();
+        this.Sender = new PacketSender();
         this.Packet = default!;
         this.IsReliable = false;
         this.Connection = default!;

--- a/src/Nalix.Runtime/Dispatching/PacketSender.cs
+++ b/src/Nalix.Runtime/Dispatching/PacketSender.cs
@@ -24,12 +24,12 @@ namespace Nalix.Runtime.Dispatching;
 /// Default packet sender that serializes a packet, optionally compresses it,
 /// optionally encrypts it, and then forwards the final buffer to the connection.
 /// </summary>
-/// <typeparam name="TPacket">The packet type carried by the sender.</typeparam>
-public sealed class PacketSender<TPacket> : IPacketSender<TPacket>, IPoolable where TPacket : IPacket
+public sealed class PacketSender : IPacketSender, IPoolable
 {
     #region Fields
 
-    private IPacketContext<TPacket>? _context;
+    private IConnection? _connection;
+    private PacketMetadata _attributes;
 
 #if DEBUG
     private static readonly ILogger? s_logger = InstanceManager.Instance.GetExistingInstance<ILogger>();
@@ -41,7 +41,7 @@ public sealed class PacketSender<TPacket> : IPacketSender<TPacket>, IPoolable wh
     #region Constructor
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="PacketSender{TPacket}"/> class.
+    /// Initializes a new instance of the <see cref="PacketSender"/> class.
     /// </summary>
     public PacketSender()
     {
@@ -52,31 +52,44 @@ public sealed class PacketSender<TPacket> : IPacketSender<TPacket>, IPoolable wh
     #region APIs
 
     /// <inheritdoc/>
-    public void ResetForPool() => _context = null;
-
-    /// <inheritdoc/>
-    public void Initialize(IPacketContext<TPacket> context) => _context = context ?? throw new ArgumentNullException(nameof(context));
-
-    /// <inheritdoc/>
-    public ValueTask SendAsync(TPacket packet, CancellationToken ct = default)
+    public void ResetForPool()
     {
-        PacketContext<TPacket> context = (PacketContext<TPacket>)this.GET_CONTEXT_OR_THROW();
-        bool needEncrypt = context.Attributes.Encryption?.IsEncrypted ?? false;
-
-        return PacketSender<TPacket>.SEND_CORE_ASYNC(context, packet, needEncrypt, ct);
+        _connection = null;
+        _attributes = default;
     }
 
     /// <inheritdoc/>
-    public ValueTask SendAsync(TPacket packet, bool forceEncrypt, CancellationToken ct = default)
-        => PacketSender<TPacket>.SEND_CORE_ASYNC(this.GET_CONTEXT_OR_THROW(), packet, forceEncrypt, ct);
+    public void Initialize<TPacket>(IPacketContext<TPacket> context) where TPacket : IPacket
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        _connection = context.Connection;
+        _attributes = context.Attributes;
+    }
+
+    /// <inheritdoc/>
+    public ValueTask SendAsync(IPacket packet, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(packet);
+        bool needEncrypt = _attributes.Encryption?.IsEncrypted ?? false;
+
+        return SEND_CORE_ASYNC(this.GET_CONNECTION_OR_THROW(), _attributes, packet, needEncrypt, ct);
+    }
+
+    /// <inheritdoc/>
+    public ValueTask SendAsync(IPacket packet, bool forceEncrypt, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(packet);
+        return SEND_CORE_ASYNC(this.GET_CONNECTION_OR_THROW(), _attributes, packet, forceEncrypt, ct);
+    }
 
     #endregion APIs
 
     #region Private Methods
 
     private static async ValueTask SEND_CORE_ASYNC(
-        IPacketContext<TPacket> context,
-        TPacket packet,
+        IConnection connection,
+        PacketMetadata attributes,
+        IPacket packet,
         bool needEncrypt,
         CancellationToken ct)
     {
@@ -102,12 +115,12 @@ public sealed class PacketSender<TPacket> : IPacketSender<TPacket>, IPoolable wh
                 s_options.Enabled,
                 s_options.MinSizeToCompress,
                 needEncrypt,
-                context.Connection.Secret.AsSpan(),
-                context.Connection.Algorithm);
+                connection.Secret.AsSpan(),
+                connection.Algorithm);
 
             try
             {
-                await GetTransport(context).SendAsync(current.Memory, ct).ConfigureAwait(false);
+                await GetTransport(connection, attributes).SendAsync(current.Memory, ct).ConfigureAwait(false);
             }
             finally
             {
@@ -126,17 +139,17 @@ public sealed class PacketSender<TPacket> : IPacketSender<TPacket>, IPoolable wh
         }
     }
 
-    private static IConnection.ITransport GetTransport(IPacketContext<TPacket> context)
+    private static IConnection.ITransport GetTransport(IConnection connection, PacketMetadata attributes)
     {
         // BUG-76: Prioritize the transport specified on the handler attribute.
         // If no attribute is present, default to TCP as per requirements.
-        NetworkTransport transport = context.Attributes.Transport?.TransportType ?? NetworkTransport.TCP;
+        NetworkTransport transport = attributes.Transport?.TransportType ?? NetworkTransport.TCP;
 
-        return transport == NetworkTransport.UDP ? context.Connection.UDP : context.Connection.TCP;
+        return transport == NetworkTransport.UDP ? connection.UDP : connection.TCP;
     }
 
-    private IPacketContext<TPacket> GET_CONTEXT_OR_THROW()
-        => _context ?? throw new InternalErrorException($"{nameof(PacketSender<>)} must be initialized before sending.");
+    private IConnection GET_CONNECTION_OR_THROW()
+        => _connection ?? throw new InternalErrorException($"{nameof(PacketSender)} must be initialized before sending.");
 
     #endregion Private Methods
 }

--- a/src/Nalix.Runtime/Internal/Results/Packet/PacketReturnHandler.cs
+++ b/src/Nalix.Runtime/Internal/Results/Packet/PacketReturnHandler.cs
@@ -22,7 +22,7 @@ internal sealed class PacketReturnHandler<TPacket> : IReturnHandler<TPacket> whe
 
         if (packet.Flags.HasFlag(PacketFlags.RELIABLE))
         {
-            await context.Sender.SendAsync((TPacket)packet).ConfigureAwait(false);
+            await context.Sender.SendAsync(packet).ConfigureAwait(false);
             return;
         }
 

--- a/src/Nalix.SDK/Transport/TcpSession.cs
+++ b/src/Nalix.SDK/Transport/TcpSession.cs
@@ -25,7 +25,6 @@ public class TcpSession : TransportSession
     private readonly SemaphoreSlim _connectionLock = new(1, 1);
     private Socket? _socket;
     private CancellationTokenSource? _loopCts;
-    private Task? _readerTask;
     private int _disposed;
 
     #endregion Fields
@@ -116,7 +115,7 @@ public class TcpSession : TransportSession
             // Start background worker for reading frames
             _loopCts = new CancellationTokenSource();
 
-            _readerTask = Task.Factory.StartNew(() => _reader.ReceiveLoopAsync(_loopCts.Token), 
+            _ = Task.Factory.StartNew(() => _reader.ReceiveLoopAsync(_loopCts.Token),
                 _loopCts.Token, TaskCreationOptions.LongRunning, TaskScheduler.Default).Unwrap();
         }
         catch (Exception ex)

--- a/tests/Nalix.Analyzers.Tests/NalixUsageAnalyzerTests.cs
+++ b/tests/Nalix.Analyzers.Tests/NalixUsageAnalyzerTests.cs
@@ -682,6 +682,31 @@ public sealed class ExplicitPacket
     }
 
     [Fact]
+    public async Task SerializeHeaderInBaseAndSerializeOrderInDerived_DoesNotReportNalix014()
+    {
+        const string source = """
+namespace Demo;
+using Nalix.Common.Serialization;
+
+[SerializePackable(SerializeLayout.Explicit)]
+public abstract class BasePacket
+{
+    [SerializeHeader(0)]
+    public int Header { get; set; }
+}
+
+[SerializePackable(SerializeLayout.Explicit)]
+public sealed class DerivedPacket : BasePacket
+{
+    [SerializeOrder(0)]
+    public int Payload { get; set; }
+}
+""";
+
+        await AnalyzerTestHarness.AssertDiagnosticIdsAsync(source);
+    }
+
+    [Fact]
     public async Task SerializeIgnoreWithOrder_ReportsNalix015()
     {
         const string source = """

--- a/tests/Nalix.Network.Pipeline.Tests/PolicyRateLimiterTests.cs
+++ b/tests/Nalix.Network.Pipeline.Tests/PolicyRateLimiterTests.cs
@@ -89,7 +89,7 @@ public sealed class PolicyRateLimiterTests
         public PacketMetadata Attributes { get; } =
             new(new PacketOpcodeAttribute(opCode), timeout: null, permission: null, encryption: null, rateLimit, concurrencyLimit: null, transport: null);
 
-        public IPacketSender<IPacket> Sender => throw new NotSupportedException();
+        public IPacketSender Sender => throw new NotSupportedException();
 
         public CancellationToken CancellationToken => CancellationToken.None;
 


### PR DESCRIPTION


## Summary

<!-- Briefly describe the purpose of this PR and what it implements or fixes. -->

Closes #<!-- issue number -->

Refactored IPacketSender and PacketSender to remove the TPacket generic parameter; both now operate on IPacket directly. Updated IPacketContext and all usages to use the non-generic sender. Adjusted PacketSender internals to store IConnection and PacketMetadata, and changed initialization and SendAsync signatures accordingly. Fixed analyzer to only check for duplicate SerializeOrder attributes, not SerializeHeader, and added a test to cover this case. Improved documentation in PacketRegistryFactory and removed unused field in TcpSession. Updated all tests and mocks for the new sender interface.

---

## Type of Change

- [ ] 🐛 Bug fix
- [ ] 🚀 Feature / enhancement
- [ ] ⚡ Performance improvement
- [x] 🔧 Refactor
- [ ] 📚 Documentation update
- [ ] 🔒 Security fix
- [ ] 🧪 Tests

---

## How to Test

<!-- Describe steps to verify this PR. -->

1.
2.
3.

---

## Screenshots (if applicable)

<!-- Add screenshots or videos for UI changes. Remove this section if not applicable. -->

---

## Additional Notes

<!-- Optional: breaking changes, dependencies, deployment notes, anything reviewers should know. -->

---

## Checklist

- [ ] Code follows project style guidelines (`.editorconfig`).
- [ ] Tests cover all changes.
- [ ] All tests pass locally (`dotnet test`).
- [ ] Documentation updated (if applicable).
- [ ] Self-reviewed my own code.
- [ ] No merge conflicts with `master`.
