### PR TITLE
refactor: directive management

### DIFF
--- a/src/Nalix.Common/Networking/ConnectionAttributes.cs
+++ b/src/Nalix.Common/Networking/ConnectionAttributes.cs
@@ -17,4 +17,25 @@ public static class ConnectionAttributes
     /// Key for the boolean attribute indicating whether a handshake has been successfully established.
     /// </summary>
     public const string HandshakeEstablished = "nalix.handshake.established";
+
+    /// <summary>
+    /// Synchronization key used to coordinate anti-spam directive send guards per connection.
+    /// </summary>
+    public const string InboundDirectiveGuardSyncRoot = "nalix.inbound.directive.guard.sync_root";
+
+    /// <summary>
+    /// Stores the last monotonic timestamp (ms) when a TIMEOUT directive was sent.
+    /// </summary>
+    public const string InboundDirectiveTimeoutLastSentAtMs = "nalix.inbound.directive.timeout.last_sent_at_ms";
+
+    /// <summary>
+    /// Stores the last monotonic timestamp (ms) when a RATE_LIMITED directive was sent.
+    /// Shared by rate-limit and concurrency middleware to avoid duplicate bursts.
+    /// </summary>
+    public const string InboundDirectiveRateLimitedLastSentAtMs = "nalix.inbound.directive.rate_limited.last_sent_at_ms";
+
+    /// <summary>
+    /// Stores the last monotonic timestamp (ms) when an UNAUTHORIZED directive was sent.
+    /// </summary>
+    public const string InboundDirectiveUnauthorizedLastSentAtMs = "nalix.inbound.directive.unauthorized.last_sent_at_ms";
 }

--- a/src/Nalix.Framework/DataFrames/Pooling/PacketPool.cs
+++ b/src/Nalix.Framework/DataFrames/Pooling/PacketPool.cs
@@ -37,13 +37,6 @@ public static class PacketPool<TPacket> where TPacket : PacketBase<TPacket>, new
     public static PacketLease<TPacket> Rent() => new(s_pool.Get());
 
     /// <summary>
-    /// Rents a packet instance directly. 
-    /// The caller is responsible for calling <c>Dispose()</c> on the returned packet.
-    /// </summary>
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static TPacket Get() => s_pool.Get();
-
-    /// <summary>
     /// Preallocates instances for this packet type to reduce cold-start latency.
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/Nalix.Network.Pipeline/Inbound/ConcurrencyMiddleware.cs
+++ b/src/Nalix.Network.Pipeline/Inbound/ConcurrencyMiddleware.cs
@@ -6,12 +6,13 @@ using System.Threading;
 using System.Threading.Tasks;
 using Nalix.Common.Exceptions;
 using Nalix.Common.Middleware;
+using Nalix.Common.Networking;
 using Nalix.Common.Networking.Packets;
 using Nalix.Common.Networking.Protocols;
+using Nalix.Framework.DataFrames.Pooling;
 using Nalix.Framework.DataFrames.SignalFrames;
 using Nalix.Framework.Injection;
-using Nalix.Framework.Memory.Buffers;
-using Nalix.Framework.Memory.Objects;
+using Nalix.Network.Pipeline.Internal;
 using Nalix.Network.Pipeline.Throttling;
 
 namespace Nalix.Network.Pipeline.Inbound;
@@ -23,7 +24,6 @@ namespace Nalix.Network.Pipeline.Inbound;
 [MiddlewareStage(MiddlewareStage.Inbound)]
 public class ConcurrencyMiddleware : IPacketMiddleware<IPacket>
 {
-    private static readonly ObjectPoolManager s_pool = InstanceManager.Instance.GetOrCreateInstance<ObjectPoolManager>();
     private readonly ConcurrencyGate _concurrencyGate;
 
     /// <inheritdoc/>
@@ -66,27 +66,24 @@ public class ConcurrencyMiddleware : IPacketMiddleware<IPacket>
 
                 if (!acquired)
                 {
-                    Directive directive = s_pool.Get<Directive>();
-
-                    try
+                    if (!DirectiveGuard.TryAcquire(
+                        context.Connection,
+                        ConnectionAttributes.InboundDirectiveRateLimitedLastSentAtMs))
                     {
-                        directive.Initialize(
-                            ControlType.FAIL,
-                            ProtocolReason.RATE_LIMITED, ProtocolAdvice.RETRY,
-                            sequenceId: context.Packet.SequenceId,
-                            controlFlags: ControlFlags.IS_TRANSIENT,
-                            arg0: context.Packet.OpCode);
-
-                        using BufferLease lease_1 = BufferLease.Rent(directive.Length + 32);
-
-                        int length = directive.Serialize(lease_1.SpanFull);
-                        lease_1.CommitLength(length);
-                        await context.Connection.TCP.SendAsync(lease_1.Memory).ConfigureAwait(false);
+                        return;
                     }
-                    finally
-                    {
-                        s_pool.Return(directive);
-                    }
+
+                    using PacketLease<Directive> packetLease = PacketPool<Directive>.Rent();
+                    Directive directive = packetLease.Value;
+
+                    directive.Initialize(
+                        ControlType.FAIL,
+                        ProtocolReason.RATE_LIMITED, ProtocolAdvice.RETRY,
+                        sequenceId: context.Packet.SequenceId,
+                        controlFlags: ControlFlags.IS_TRANSIENT,
+                        arg0: context.Packet.OpCode);
+
+                    await context.Sender.SendAsync(directive).ConfigureAwait(false);
 
                     return;
                 }
@@ -96,27 +93,24 @@ public class ConcurrencyMiddleware : IPacketMiddleware<IPacket>
         }
         catch (ConcurrencyFailureException)
         {
-            Directive directive = s_pool.Get<Directive>();
-
-            try
+            if (!DirectiveGuard.TryAcquire(
+                context.Connection,
+                ConnectionAttributes.InboundDirectiveRateLimitedLastSentAtMs))
             {
-                directive.Initialize(
-                    ControlType.FAIL,
-                    ProtocolReason.RATE_LIMITED, ProtocolAdvice.RETRY,
-                    sequenceId: context.Packet.SequenceId,
-                    controlFlags: ControlFlags.IS_TRANSIENT,
-                    arg0: context.Packet.OpCode);
-
-                using BufferLease lease_1 = BufferLease.Rent(directive.Length + 32);
-
-                int length = directive.Serialize(lease_1.SpanFull);
-                lease_1.CommitLength(length);
-                await context.Connection.TCP.SendAsync(lease_1.Memory).ConfigureAwait(false);
+                return;
             }
-            finally
-            {
-                s_pool.Return(directive);
-            }
+
+            using PacketLease<Directive> packetLease = PacketPool<Directive>.Rent();
+            Directive directive = packetLease.Value;
+
+            directive.Initialize(
+                ControlType.FAIL,
+                ProtocolReason.RATE_LIMITED, ProtocolAdvice.RETRY,
+                sequenceId: context.Packet.SequenceId,
+                controlFlags: ControlFlags.IS_TRANSIENT,
+                arg0: context.Packet.OpCode);
+
+            await context.Sender.SendAsync(directive).ConfigureAwait(false);
         }
         finally
         {

--- a/src/Nalix.Network.Pipeline/Inbound/PermissionMiddleware.cs
+++ b/src/Nalix.Network.Pipeline/Inbound/PermissionMiddleware.cs
@@ -6,12 +6,13 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Nalix.Common.Middleware;
+using Nalix.Common.Networking;
 using Nalix.Common.Networking.Packets;
 using Nalix.Common.Networking.Protocols;
+using Nalix.Framework.DataFrames.Pooling;
 using Nalix.Framework.DataFrames.SignalFrames;
 using Nalix.Framework.Injection;
-using Nalix.Framework.Memory.Buffers;
-using Nalix.Framework.Memory.Objects;
+using Nalix.Network.Pipeline.Internal;
 
 
 namespace Nalix.Network.Pipeline.Inbound;
@@ -24,8 +25,6 @@ namespace Nalix.Network.Pipeline.Inbound;
 [MiddlewareStage(MiddlewareStage.Inbound)]
 public class PermissionMiddleware : IPacketMiddleware<IPacket>
 {
-    private static readonly ObjectPoolManager s_pool = InstanceManager.Instance.GetOrCreateInstance<ObjectPoolManager>();
-
     private readonly ILogger? _logger;
 
     /// <inheritdoc/>
@@ -58,7 +57,15 @@ public class PermissionMiddleware : IPacketMiddleware<IPacket>
             $"[NW.{nameof(PermissionMiddleware)}] deny op=0x{context.Attributes.PacketOpcode.OpCode:X4} " +
             $"need={context.Attributes.Permission?.Level.ToString() ?? "N/A (no attribute)"} have={context.Connection.Level}");
 
-        Directive directive = s_pool.Get<Directive>();
+        if (!DirectiveGuard.TryAcquire(
+            context.Connection,
+            ConnectionAttributes.InboundDirectiveUnauthorizedLastSentAtMs))
+        {
+            return;
+        }
+
+        using PacketLease<Directive> lease = PacketPool<Directive>.Rent();
+        Directive directive = lease.Value;
 
         try
         {
@@ -71,19 +78,11 @@ public class PermissionMiddleware : IPacketMiddleware<IPacket>
                 arg1: 0,
                 arg2: context.Attributes.PacketOpcode.OpCode);
 
-            using BufferLease lease = BufferLease.Rent(directive.Length + 32);
-
-            int length = directive.Serialize(lease.SpanFull);
-            lease.CommitLength(length);
-            await context.Connection.TCP.SendAsync(lease.Memory).ConfigureAwait(false);
+            await context.Sender.SendAsync(directive).ConfigureAwait(false);
         }
         catch (Exception ex)
         {
             context.Connection.ThrottledError(_logger, "middleware.permission.send_error", $"[NW.{nameof(PermissionMiddleware)}] send-error-failed", ex);
-        }
-        finally
-        {
-            s_pool.Return(directive);
         }
     }
 }

--- a/src/Nalix.Network.Pipeline/Inbound/RateLimitMiddleware.cs
+++ b/src/Nalix.Network.Pipeline/Inbound/RateLimitMiddleware.cs
@@ -6,12 +6,13 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Nalix.Common.Middleware;
+using Nalix.Common.Networking;
 using Nalix.Common.Networking.Packets;
 using Nalix.Common.Networking.Protocols;
+using Nalix.Framework.DataFrames.Pooling;
 using Nalix.Framework.DataFrames.SignalFrames;
 using Nalix.Framework.Injection;
-using Nalix.Framework.Memory.Buffers;
-using Nalix.Framework.Memory.Objects;
+using Nalix.Network.Pipeline.Internal;
 using Nalix.Network.Pipeline.Throttling;
 
 namespace Nalix.Network.Pipeline.Inbound;
@@ -23,8 +24,6 @@ namespace Nalix.Network.Pipeline.Inbound;
 [MiddlewareStage(MiddlewareStage.Inbound)]
 public class RateLimitMiddleware : IPacketMiddleware<IPacket>
 {
-    private static readonly ObjectPoolManager s_pool = InstanceManager.Instance.GetOrCreateInstance<ObjectPoolManager>();
-
     private readonly ILogger? _logger;
     private readonly PolicyRateLimiter _policy;
     private readonly TokenBucketLimiter _global;
@@ -86,29 +85,26 @@ public class RateLimitMiddleware : IPacketMiddleware<IPacket>
 
         if (!decision.Allowed)
         {
-            Directive directive = s_pool.Get<Directive>();
+            if (!DirectiveGuard.TryAcquire(
+                context.Connection,
+                ConnectionAttributes.InboundDirectiveRateLimitedLastSentAtMs))
+            {
+                return;
+            }
 
             // Unified response format: FAIL + RETRY (consistent with RateLimitMiddleware)
-            try
-            {
-                directive.Initialize(
-                    ControlType.FAIL, ProtocolReason.RATE_LIMITED, ProtocolAdvice.RETRY,
-                    sequenceId: context.Packet.SequenceId,
-                    controlFlags: ControlFlags.IS_TRANSIENT,
-                    arg0: context.Attributes.PacketOpcode?.OpCode ?? 0u,
-                    arg1: (uint)decision.RetryAfterMs,
-                    arg2: decision.Credit);
+            using PacketLease<Directive> lease = PacketPool<Directive>.Rent();
+            Directive directive = lease.Value;
 
-                using BufferLease lease = BufferLease.Rent(directive.Length + 32);
+            directive.Initialize(
+                ControlType.FAIL, ProtocolReason.RATE_LIMITED, ProtocolAdvice.RETRY,
+                sequenceId: context.Packet.SequenceId,
+                controlFlags: ControlFlags.IS_TRANSIENT,
+                arg0: context.Attributes.PacketOpcode?.OpCode ?? 0u,
+                arg1: (uint)decision.RetryAfterMs,
+                arg2: decision.Credit);
 
-                int length = directive.Serialize(lease.SpanFull);
-                lease.CommitLength(length);
-                await context.Connection.TCP.SendAsync(lease.Memory).ConfigureAwait(false);
-            }
-            finally
-            {
-                s_pool.Return(directive);
-            }
+            await context.Sender.SendAsync(directive, CancellationToken.None).ConfigureAwait(false);
 
             return;
         }

--- a/src/Nalix.Network.Pipeline/Inbound/TimeoutMiddleware.cs
+++ b/src/Nalix.Network.Pipeline/Inbound/TimeoutMiddleware.cs
@@ -5,12 +5,12 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Nalix.Common.Middleware;
+using Nalix.Common.Networking;
 using Nalix.Common.Networking.Packets;
 using Nalix.Common.Networking.Protocols;
+using Nalix.Framework.DataFrames.Pooling;
 using Nalix.Framework.DataFrames.SignalFrames;
-using Nalix.Framework.Injection;
-using Nalix.Framework.Memory.Buffers;
-using Nalix.Framework.Memory.Objects;
+using Nalix.Network.Pipeline.Internal;
 
 namespace Nalix.Network.Pipeline.Inbound;
 
@@ -22,8 +22,6 @@ namespace Nalix.Network.Pipeline.Inbound;
 [MiddlewareStage(MiddlewareStage.Inbound)]
 public sealed class TimeoutMiddleware : IPacketMiddleware<IPacket>
 {
-    private static readonly ObjectPoolManager s_pool = InstanceManager.Instance.GetOrCreateInstance<ObjectPoolManager>();
-
     /// <inheritdoc/>
     public async ValueTask InvokeAsync(IPacketContext<IPacket> context, Func<CancellationToken, ValueTask> next)
     {
@@ -58,26 +56,23 @@ public sealed class TimeoutMiddleware : IPacketMiddleware<IPacket>
         }
         catch (OperationCanceledException) when (token.IsCancellationRequested && !context.CancellationToken.IsCancellationRequested)
         {
-            Directive directive = s_pool.Get<Directive>();
-
-            try
+            if (!DirectiveGuard.TryAcquire(
+                context.Connection,
+                ConnectionAttributes.InboundDirectiveTimeoutLastSentAtMs))
             {
-                directive.Initialize(
-                    ControlType.TIMEOUT, ProtocolReason.TIMEOUT, ProtocolAdvice.RETRY,
-                    sequenceId: context.Packet.SequenceId,
-                    controlFlags: ControlFlags.IS_TRANSIENT,
-                    arg0: (uint)(timeout / 100));
-
-                using BufferLease lease = BufferLease.Rent(directive.Length + 32);
-
-                int length = directive.Serialize(lease.SpanFull);
-                lease.CommitLength(length);
-                await context.Connection.TCP.SendAsync(lease.Memory, CancellationToken.None).ConfigureAwait(false);
+                return;
             }
-            finally
-            {
-                s_pool.Return(directive);
-            }
+
+            using PacketLease<Directive> lease = PacketPool<Directive>.Rent();
+            Directive directive = lease.Value;
+
+            directive.Initialize(
+                ControlType.TIMEOUT, ProtocolReason.TIMEOUT, ProtocolAdvice.RETRY,
+                sequenceId: context.Packet.SequenceId,
+                controlFlags: ControlFlags.IS_TRANSIENT,
+                arg0: (uint)(timeout / 100));
+
+            await context.Sender.SendAsync(directive, CancellationToken.None).ConfigureAwait(false);
         }
     }
 }

--- a/src/Nalix.Network.Pipeline/Internal/DirectiveGuard.cs
+++ b/src/Nalix.Network.Pipeline/Internal/DirectiveGuard.cs
@@ -4,6 +4,8 @@
 using System;
 using Nalix.Common.Abstractions;
 using Nalix.Common.Networking;
+using Nalix.Framework.Configuration;
+using Nalix.Network.Pipeline.Options;
 
 namespace Nalix.Network.Pipeline.Internal;
 
@@ -13,26 +15,28 @@ namespace Nalix.Network.Pipeline.Internal;
 /// </summary>
 internal static class DirectiveGuard
 {
-    /// <summary>
-    /// Default minimum interval between repeated directives of the same kind.
-    /// </summary>
-    private const int DefaultCooldownMs = 200;
+    private static readonly DirectiveGuardOptions s_options = ConfigurationManager.Instance.Get<DirectiveGuardOptions>();
+
+    static DirectiveGuard() => s_options.Validate();
 
     /// <summary>
     /// Attempts to acquire permission to send a directive for the provided attribute key.
     /// </summary>
     /// <param name="connection">Target connection.</param>
     /// <param name="lastSentAtAttributeKey">Attribute key that stores the last send timestamp.</param>
-    /// <param name="cooldownMs">Cooldown window in milliseconds.</param>
+    /// <param name="cooldownMs">
+    /// Optional cooldown window in milliseconds. If null, <see cref="DirectiveGuardOptions.DefaultCooldownMs"/> is used.
+    /// </param>
     /// <returns>
     /// <c>true</c> if sending is allowed now; otherwise <c>false</c> when suppressed by cooldown.
     /// </returns>
-    public static bool TryAcquire(IConnection connection, string lastSentAtAttributeKey, int cooldownMs = DefaultCooldownMs)
+    public static bool TryAcquire(IConnection connection, string lastSentAtAttributeKey, int? cooldownMs = null)
     {
         ArgumentNullException.ThrowIfNull(connection);
         ArgumentNullException.ThrowIfNull(lastSentAtAttributeKey);
 
-        if (cooldownMs <= 0)
+        int resolvedCooldownMs = cooldownMs ?? s_options.DefaultCooldownMs;
+        if (resolvedCooldownMs <= 0)
         {
             return true;
         }
@@ -45,7 +49,7 @@ internal static class DirectiveGuard
             long nowMs = Environment.TickCount64;
             if (attributes.TryGetValue(lastSentAtAttributeKey, out object? boxed) &&
                 boxed is long lastSentAtMs &&
-                unchecked(nowMs - lastSentAtMs) < cooldownMs)
+                unchecked(nowMs - lastSentAtMs) < resolvedCooldownMs)
             {
                 return false;
             }
@@ -76,4 +80,3 @@ internal static class DirectiveGuard
         return created;
     }
 }
-

--- a/src/Nalix.Network.Pipeline/Internal/DirectiveGuard.cs
+++ b/src/Nalix.Network.Pipeline/Internal/DirectiveGuard.cs
@@ -1,0 +1,79 @@
+// Copyright (c) 2025-2026 PPN Corporation. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using System;
+using Nalix.Common.Abstractions;
+using Nalix.Common.Networking;
+
+namespace Nalix.Network.Pipeline.Internal;
+
+/// <summary>
+/// Connection-scoped anti-spam guard for inbound directive responses.
+/// Uses connection attributes to track last send times and suppress burst replies.
+/// </summary>
+internal static class DirectiveGuard
+{
+    /// <summary>
+    /// Default minimum interval between repeated directives of the same kind.
+    /// </summary>
+    private const int DefaultCooldownMs = 200;
+
+    /// <summary>
+    /// Attempts to acquire permission to send a directive for the provided attribute key.
+    /// </summary>
+    /// <param name="connection">Target connection.</param>
+    /// <param name="lastSentAtAttributeKey">Attribute key that stores the last send timestamp.</param>
+    /// <param name="cooldownMs">Cooldown window in milliseconds.</param>
+    /// <returns>
+    /// <c>true</c> if sending is allowed now; otherwise <c>false</c> when suppressed by cooldown.
+    /// </returns>
+    public static bool TryAcquire(IConnection connection, string lastSentAtAttributeKey, int cooldownMs = DefaultCooldownMs)
+    {
+        ArgumentNullException.ThrowIfNull(connection);
+        ArgumentNullException.ThrowIfNull(lastSentAtAttributeKey);
+
+        if (cooldownMs <= 0)
+        {
+            return true;
+        }
+
+        IObjectMap<string, object> attributes = connection.Attributes;
+        object syncRoot = GET_OR_CREATE_SYNC_ROOT(attributes);
+
+        lock (syncRoot)
+        {
+            long nowMs = Environment.TickCount64;
+            if (attributes.TryGetValue(lastSentAtAttributeKey, out object? boxed) &&
+                boxed is long lastSentAtMs &&
+                unchecked(nowMs - lastSentAtMs) < cooldownMs)
+            {
+                return false;
+            }
+
+            attributes[lastSentAtAttributeKey] = nowMs;
+            return true;
+        }
+    }
+
+    private static object GET_OR_CREATE_SYNC_ROOT(IObjectMap<string, object> attributes)
+    {
+        if (attributes.TryGetValue(ConnectionAttributes.InboundDirectiveGuardSyncRoot, out object? existing) &&
+            existing is object syncRoot)
+        {
+            return syncRoot;
+        }
+
+        object created = new();
+        attributes.Add(ConnectionAttributes.InboundDirectiveGuardSyncRoot, created);
+
+        if (attributes.TryGetValue(ConnectionAttributes.InboundDirectiveGuardSyncRoot, out existing) &&
+            existing is object resolved)
+        {
+            return resolved;
+        }
+
+        attributes[ConnectionAttributes.InboundDirectiveGuardSyncRoot] = created;
+        return created;
+    }
+}
+

--- a/src/Nalix.Network.Pipeline/Options/DirectiveGuardOptions.cs
+++ b/src/Nalix.Network.Pipeline/Options/DirectiveGuardOptions.cs
@@ -1,0 +1,33 @@
+// Copyright (c) 2025-2026 PPN Corporation. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using System.ComponentModel.DataAnnotations;
+using Nalix.Common.Abstractions;
+using Nalix.Framework.Configuration.Binding;
+
+namespace Nalix.Network.Pipeline.Options;
+
+/// <summary>
+/// Configuration for inbound directive anti-spam guard behavior.
+/// </summary>
+[IniComment("Inbound directive guard configuration — controls cooldown used to suppress repeated fail/timeout responses")]
+public sealed class DirectiveGuardOptions : ConfigurationLoader
+{
+    /// <summary>
+    /// Minimum interval (milliseconds) between repeated directives of the same category per connection.
+    /// Set to 0 to disable suppression.
+    /// </summary>
+    [IniComment("Minimum cooldown in milliseconds for repeated inbound directives (0 = disabled, default 200)")]
+    [Range(0, 60000, ErrorMessage = "DefaultCooldownMs must be between 0 and 60000.")]
+    public int DefaultCooldownMs { get; set; } = 200;
+
+    /// <summary>
+    /// Validates option values.
+    /// </summary>
+    public void Validate()
+    {
+        ValidationContext context = new(this);
+        Validator.ValidateObject(this, context, validateAllProperties: true);
+    }
+}
+

--- a/src/Nalix.Runtime/Extensions/ConnectionExtensions.cs
+++ b/src/Nalix.Runtime/Extensions/ConnectionExtensions.cs
@@ -6,10 +6,8 @@ using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using Nalix.Common.Networking;
 using Nalix.Common.Networking.Protocols;
+using Nalix.Framework.DataFrames.Pooling;
 using Nalix.Framework.DataFrames.SignalFrames;
-using Nalix.Framework.Injection;
-using Nalix.Framework.Memory.Buffers;
-using Nalix.Framework.Memory.Objects;
 
 namespace Nalix.Runtime.Extensions;
 
@@ -18,8 +16,6 @@ namespace Nalix.Runtime.Extensions;
 /// </summary>
 public static class ConnectionExtensions
 {
-    private static readonly ObjectPoolManager s_pool = InstanceManager.Instance.GetOrCreateInstance<ObjectPoolManager>();
-
     /// <summary>
     /// Sends a control directive asynchronously over the connection.
     /// </summary>
@@ -38,28 +34,18 @@ public static class ConnectionExtensions
     {
         ArgumentNullException.ThrowIfNull(connection);
 
-        Directive directive = s_pool.Get<Directive>();
+        using PacketLease<Directive> lease = PacketPool<Directive>.Rent();
+        Directive directive = lease.Value;
 
-        try
-        {
-            directive.Initialize(
-                controlType, reason, action,
-                sequenceId: options.SequenceId,
-                controlFlags: options.Flags,
-                arg0: options.Arg0,
-                arg1: options.Arg1,
-                arg2: options.Arg2);
+        directive.Initialize(
+            controlType, reason, action,
+            sequenceId: options.SequenceId,
+            controlFlags: options.Flags,
+            arg0: options.Arg0,
+            arg1: options.Arg1,
+            arg2: options.Arg2);
 
-            using BufferLease lease = BufferLease.Rent(directive.Length + 32);
-
-            int length = directive.Serialize(lease.SpanFull);
-            lease.CommitLength(length);
-            await connection.TCP.SendAsync(lease.Memory).ConfigureAwait(false);
-        }
-        finally
-        {
-            s_pool.Return(directive);
-        }
+        await connection.TCP.SendAsync(directive).ConfigureAwait(false);
     }
 }
 

--- a/tests/Nalix.Framework.Tests/DataFrames/PacketPoolLeaseTests.cs
+++ b/tests/Nalix.Framework.Tests/DataFrames/PacketPoolLeaseTests.cs
@@ -1,8 +1,6 @@
 // Copyright (c) 2026 PPN Corporation. All rights reserved.
 // Licensed under the Apache License, Version 2.0.
 
-using Nalix.Common.Networking.Packets;
-using Nalix.Common.Networking.Protocols;
 using Nalix.Framework.DataFrames.Pooling;
 using Nalix.Framework.DataFrames.SignalFrames;
 using Xunit;
@@ -21,38 +19,6 @@ public sealed class PacketPoolLeaseTests
         // explicit second dispose should be ignored
         lease.Dispose();
         lease.Dispose();
-    }
-
-    [Fact]
-    public void ReturnThenGetResetsControlPacketState()
-    {
-        _ = PacketPool<Control>.Clear();
-
-        Control packet = PacketPool<Control>.Get();
-        packet.Initialize(
-            opCode: 1234,
-            type: ControlType.DISCONNECT,
-            sequenceId: 42,
-            reasonCode: ProtocolReason.INTERNAL_ERROR,
-            flags: PacketFlags.SYSTEM | PacketFlags.UNRELIABLE);
-        packet.Priority = PacketPriority.LOW;
-
-        packet.Dispose();
-
-        Control reused = PacketPool<Control>.Get();
-        try
-        {
-            Assert.Equal(0u, reused.SequenceId);
-            Assert.Equal(ControlType.NONE, reused.Type);
-            Assert.Equal(ProtocolReason.NONE, reused.Reason);
-            Assert.Equal(PacketPriority.HIGH, reused.Priority);
-            Assert.Equal(0L, reused.Timestamp);
-            Assert.Equal(0L, reused.MonoTicks);
-        }
-        finally
-        {
-            reused.Dispose();
-        }
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

<!-- Briefly describe the purpose of this PR and what it implements or fixes. -->

Closes #<!-- issue number -->

This pull request introduces a new anti-spam mechanism for sending directive responses to clients, ensuring that repeated fail/timeout/rate-limited/unauthorized directives are not sent in rapid succession to the same connection. It does so by adding a connection-scoped cooldown guard (`DirectiveGuard`) and refactoring all relevant middleware to use this guard, as well as simplifying packet allocation and sending logic. Additionally, new configuration options allow tuning the cooldown interval.

Key changes:

**Anti-Spam Guard for Directive Responses:**

* Added the new `DirectiveGuard` utility (`DirectiveGuard.cs`), which tracks the last time a directive was sent per connection and suppresses repeated directives within a configurable cooldown window. This prevents spamming clients with repeated error/control directives. (`[src/Nalix.Network.Pipeline/Internal/DirectiveGuard.csR1-R82](diffhunk://#diff-9cc6dd1248947afd5dea4f1ec23353e92c0b757d901033acc12f797bf5eefd19R1-R82)`)
* Introduced `DirectiveGuardOptions` (`DirectiveGuardOptions.cs`) to configure the minimum cooldown interval between repeated directives, with validation and a default of 200ms. (`[src/Nalix.Network.Pipeline/Options/DirectiveGuardOptions.csR1-R33](diffhunk://#diff-0ff7147dfb8793bdd5c7b83e51b14894d6807f28e95941a8feb4d3505dd7fc7dR1-R33)`)
* Extended `ConnectionAttributes` with new keys for tracking last sent timestamps for each directive type and a sync root for thread safety. (`[src/Nalix.Common/Networking/ConnectionAttributes.csR20-R40](diffhunk://#diff-a4e144f43cb242faa5f5241e504e9a5e092ae98d27a3a9f7cac55004a63d2253R20-R40)`)

**Middleware Refactoring:**

* Refactored `ConcurrencyMiddleware`, `RateLimitMiddleware`, `TimeoutMiddleware`, and `PermissionMiddleware` to use `DirectiveGuard.TryAcquire` before sending directives, preventing burst responses. Packet allocation is now handled with `PacketPool<Directive>.Rent()` and sending is done via `context.Sender.SendAsync`. (`[[1]](diffhunk://#diff-d6414162d5e208fef9f4af54820f0734b86fd1a60004bd6e46487377cd585416L69-R86)`, `[[2]](diffhunk://#diff-d6414162d5e208fef9f4af54820f0734b86fd1a60004bd6e46487377cd585416L99-R113)`, `[[3]](diffhunk://#diff-0a25f214216abb11a68a3092e2bfe568be33bb758ba4ca36143e46a250a575c7L61-R68)`, `[[4]](diffhunk://#diff-0a25f214216abb11a68a3092e2bfe568be33bb758ba4ca36143e46a250a575c7L74-L87)`, `[[5]](diffhunk://#diff-c469b3a1b7fe2900d9be653651e34cb2cd20883f15f57db4c5870ca78f3ba581L89-R98)`, `[[6]](diffhunk://#diff-c469b3a1b7fe2900d9be653651e34cb2cd20883f15f57db4c5870ca78f3ba581L102-R107)`, `[[7]](diffhunk://#diff-aab72a406ff3a98f96aa60d800843943bb004cea3d407805275652fc18112176L61-R75)`)
* Removed use of the old `ObjectPoolManager` and manual buffer management in favor of the new pooling and sending pattern. (`[[1]](diffhunk://#diff-d6414162d5e208fef9f4af54820f0734b86fd1a60004bd6e46487377cd585416L26)`, `[[2]](diffhunk://#diff-0a25f214216abb11a68a3092e2bfe568be33bb758ba4ca36143e46a250a575c7L27-L28)`, `[[3]](diffhunk://#diff-c469b3a1b7fe2900d9be653651e34cb2cd20883f15f57db4c5870ca78f3ba581L26-L27)`, `[[4]](diffhunk://#diff-aab72a406ff3a98f96aa60d800843943bb004cea3d407805275652fc18112176L25-L26)`, `[[5]](diffhunk://#diff-97a2b3b05266adcea3c5d8b4eae5f25356f3160917ccc2906f11bf090a133550L21-L22)`)

**Codebase Simplification and Cleanup:**

* Removed the direct `Get()` method from `PacketPool` to encourage use of the safer `PacketLease` pattern. (`[src/Nalix.Framework/DataFrames/Pooling/PacketPool.csL39-L45](diffhunk://#diff-cd80c373b584aad63df0557ca2280c422e2124bd913ddca1a69b175620277f7eL39-L45)`)
* Updated using directives and removed unnecessary dependencies in all affected files. (`[[1]](diffhunk://#diff-d6414162d5e208fef9f4af54820f0734b86fd1a60004bd6e46487377cd585416R9-R15)`, `[[2]](diffhunk://#diff-0a25f214216abb11a68a3092e2bfe568be33bb758ba4ca36143e46a250a575c7R9-R15)`, `[[3]](diffhunk://#diff-c469b3a1b7fe2900d9be653651e34cb2cd20883f15f57db4c5870ca78f3ba581R9-R15)`, `[[4]](diffhunk://#diff-aab72a406ff3a98f96aa60d800843943bb004cea3d407805275652fc18112176R8-R13)`, `[[5]](diffhunk://#diff-97a2b3b05266adcea3c5d8b4eae5f25356f3160917ccc2906f11bf090a133550R9-L12)`)

These changes make the server more robust against client-side abuse, simplify the directive sending code, and provide a clear configuration point for controlling anti-spam behavior.

---

## Type of Change

- [ ] 🐛 Bug fix
- [ ] 🚀 Feature / enhancement
- [ ] ⚡ Performance improvement
- [x] 🔧 Refactor
- [ ] 📚 Documentation update
- [ ] 🔒 Security fix
- [ ] 🧪 Tests

---

## How to Test

<!-- Describe steps to verify this PR. -->

1.
2.
3.

---

## Screenshots (if applicable)

<!-- Add screenshots or videos for UI changes. Remove this section if not applicable. -->

---

## Additional Notes

<!-- Optional: breaking changes, dependencies, deployment notes, anything reviewers should know. -->

---

## Checklist

- [ ] Code follows project style guidelines (`.editorconfig`).
- [ ] Tests cover all changes.
- [ ] All tests pass locally (`dotnet test`).
- [ ] Documentation updated (if applicable).
- [ ] Self-reviewed my own code.
- [ ] No merge conflicts with `master`.
