### PR TITLE
fix(network): replay-window wrap-around

### DIFF
--- a/NuGet.Config
+++ b/NuGet.Config
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<configuration>
-  <packageSources>
-    <clear />
-    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
-  </packageSources>
-</configuration>

--- a/src/Nalix.Network/Internal/Security/SlidingWindow.cs
+++ b/src/Nalix.Network/Internal/Security/SlidingWindow.cs
@@ -18,9 +18,12 @@ namespace Nalix.Network.Internal.Security;
 /// </summary>
 internal sealed class SlidingWindow
 {
+    private const int SequenceHalfRange = (ushort.MaxValue + 1) / 2;
+
     private readonly int _windowSize;
     private readonly int _arraySize;
-    private long _maxSeen;
+    private ushort _maxSeen;
+    private bool _isInitialized;
     private readonly long[] _bitmap;
     private SpinLock _spinLock;
 
@@ -31,7 +34,7 @@ internal sealed class SlidingWindow
     public SlidingWindow(int windowSize = 1024)
     {
         _windowSize = windowSize;
-        _arraySize = windowSize / 64;
+        _arraySize = (windowSize + 63) / 64;
         _bitmap = new long[_arraySize];
     }
 
@@ -47,13 +50,23 @@ internal sealed class SlidingWindow
         try
         {
             _spinLock.Enter(ref lockTaken);
-            long s = seq;
-            long currentMax = _maxSeen;
+            if (!_isInitialized)
+            {
+                _isInitialized = true;
+                _maxSeen = seq;
+                this.MARK_BIT(0);
+                return true;
+            }
 
-            if (s > currentMax)
+            ushort currentMax = _maxSeen;
+            int forward = unchecked((ushort)(seq - currentMax));
+
+            // 16-bit modular comparison:
+            // forward in (0, 32768) means seq is newer than currentMax, including wrap-around (65535 -> 0).
+            if (forward != 0 && forward < SequenceHalfRange)
             {
                 // Advance window
-                long shift = s - currentMax;
+                long shift = forward;
                 if (shift >= _windowSize)
                 {
                     Array.Clear(_bitmap);
@@ -62,12 +75,12 @@ internal sealed class SlidingWindow
                 {
                     this.SHIFT_BITMAP(shift);
                 }
-                _maxSeen = s;
+                _maxSeen = seq;
                 this.MARK_BIT(0);
                 return true;
             }
 
-            long diff = currentMax - s;
+            int diff = unchecked((ushort)(currentMax - seq));
             if (diff >= _windowSize)
             {
                 return false; // Too old

--- a/tests/Nalix.Network.Test/SlidingWindowTests.cs
+++ b/tests/Nalix.Network.Test/SlidingWindowTests.cs
@@ -1,0 +1,59 @@
+using System;
+using System.Reflection;
+using FluentAssertions;
+using Xunit;
+
+namespace Nalix.Network.Tests;
+
+public sealed class SlidingWindowTests
+{
+    private static readonly Type s_slidingWindowType = ResolveSlidingWindowType();
+    private static readonly MethodInfo s_tryCheckMethod =
+        s_slidingWindowType.GetMethod("TryCheck", [typeof(ushort)])
+        ?? throw new InvalidOperationException("Unable to resolve SlidingWindow.TryCheck(ushort).");
+
+    [Fact]
+    public void TryCheck_WrapAround_65535To0_AcceptsNewPackets()
+    {
+        object window = CreateWindow(windowSize: 1024);
+
+        InvokeTryCheck(window, 65534).Should().BeTrue();
+        InvokeTryCheck(window, 65535).Should().BeTrue();
+        InvokeTryCheck(window, 0).Should().BeTrue();
+        InvokeTryCheck(window, 1).Should().BeTrue();
+    }
+
+    [Fact]
+    public void TryCheck_WrapAround_ReplayedPackets_AreRejected()
+    {
+        object window = CreateWindow(windowSize: 1024);
+
+        InvokeTryCheck(window, 65535).Should().BeTrue();
+        InvokeTryCheck(window, 0).Should().BeTrue();
+
+        InvokeTryCheck(window, 65535).Should().BeFalse();
+        InvokeTryCheck(window, 0).Should().BeFalse();
+    }
+
+    [Fact]
+    public void TryCheck_WrapAround_OutOfOrderWithinWindow_AcceptsPacket()
+    {
+        object window = CreateWindow(windowSize: 1024);
+
+        InvokeTryCheck(window, 65534).Should().BeTrue();
+        InvokeTryCheck(window, 0).Should().BeTrue();
+        InvokeTryCheck(window, 65535).Should().BeTrue();
+    }
+
+    private static object CreateWindow(int windowSize)
+        => Activator.CreateInstance(s_slidingWindowType, [windowSize])
+           ?? throw new InvalidOperationException("Unable to instantiate SlidingWindow.");
+
+    private static bool InvokeTryCheck(object window, ushort seq)
+        => (bool)(s_tryCheckMethod.Invoke(window, [seq])
+                  ?? throw new InvalidOperationException("SlidingWindow.TryCheck returned null."));
+
+    private static Type ResolveSlidingWindowType()
+        => Type.GetType("Nalix.Network.Internal.Security.SlidingWindow, Nalix.Network")
+           ?? throw new InvalidOperationException("Unable to resolve Nalix.Network.Internal.Security.SlidingWindow.");
+}


### PR DESCRIPTION
## Summary

<!-- Briefly describe the purpose of this PR and what it implements or fixes. -->

This pull request improves the handling of 16-bit sequence number wrap-around in the `SlidingWindow` class, ensuring correct acceptance and rejection of packets when sequence numbers roll over (e.g., from 65535 to 0). It also adds comprehensive unit tests to verify this behavior. Additionally, a redundant configuration file was removed.

**Improvements to sequence number handling:**

* Refactored `SlidingWindow` to use 16-bit modular arithmetic for sequence comparison, ensuring correct behavior when sequence numbers wrap around (e.g., 65535 → 0). The class now uses `ushort` for `_maxSeen`, introduces a `SequenceHalfRange` constant, and updates the logic in `TryCheck` for modular comparisons. [[1]](diffhunk://#diff-b2d841e13225f03bed7cdf1ce0816e1c32c21da571143f634a02154cee0e213dR21-R26) [[2]](diffhunk://#diff-b2d841e13225f03bed7cdf1ce0816e1c32c21da571143f634a02154cee0e213dL50-R69) [[3]](diffhunk://#diff-b2d841e13225f03bed7cdf1ce0816e1c32c21da571143f634a02154cee0e213dL65-R83)
* Fixed calculation of `_arraySize` in the constructor to handle non-multiples of 64 correctly.

**Testing improvements:**

* Added `SlidingWindowTests` to verify correct behavior for sequence number wrap-around, including acceptance of new packets, rejection of replays, and handling of out-of-order packets within the window.

**Project cleanup:**

* Removed the obsolete `NuGet.Config` file.

---

## Type of Change

- [x] 🐛 Bug fix
- [ ] 🚀 Feature / enhancement
- [ ] ⚡ Performance improvement
- [x] 🔧 Refactor
- [ ] 📚 Documentation update
- [ ] 🔒 Security fix
- [ ] 🧪 Tests

---

## Checklist

- [x] Code follows project style guidelines (`.editorconfig`).
- [x] Tests cover all changes.
- [x] All tests pass locally (`dotnet test`).
- [x] Documentation updated (if applicable).
- [x] Self-reviewed my own code.
- [x] No merge conflicts with `master`.
