### PR TITLE
fix(runtime): null-forced TCP send in session failure path

### DIFF
--- a/src/Nalix.Runtime/Handlers/SessionHandlers.cs
+++ b/src/Nalix.Runtime/Handlers/SessionHandlers.cs
@@ -162,18 +162,23 @@ public sealed class SessionHandlers
     /// <param name="reason">The failure reason to report.</param>
     private static async ValueTask HandleFailureAsync(IConnection connection, ProtocolReason reason)
     {
+        IConnection.ITransport? tcp = connection.TCP;
+
         using PacketLease<SessionResume> lease = PacketPool<SessionResume>.Rent();
         SessionResume ack = lease.Value;
         ack.Initialize(
             stage: SessionResumeStage.RESPONSE,
             sessionToken: default,
             reason: reason,
-            flags: PacketFlags.SYSTEM | (connection.TCP != null ? PacketFlags.RELIABLE : PacketFlags.UNRELIABLE));
+            flags: PacketFlags.SYSTEM | (tcp is not null ? PacketFlags.RELIABLE : PacketFlags.UNRELIABLE));
 
         try
         {
-            await connection.TCP!.SendAsync(ack)
-                                 .ConfigureAwait(false);
+            if (tcp is not null)
+            {
+                await tcp.SendAsync(ack)
+                         .ConfigureAwait(false);
+            }
         }
         finally
         {

--- a/src/Nalix.Runtime/Handlers/SessionHandlers.cs
+++ b/src/Nalix.Runtime/Handlers/SessionHandlers.cs
@@ -162,7 +162,7 @@ public sealed class SessionHandlers
     /// <param name="reason">The failure reason to report.</param>
     private static async ValueTask HandleFailureAsync(IConnection connection, ProtocolReason reason)
     {
-        IConnection.ITransport? tcp = connection.TCP;
+        IConnection.ITransport tcp = connection.TCP;
 
         using PacketLease<SessionResume> lease = PacketPool<SessionResume>.Rent();
         SessionResume ack = lease.Value;
@@ -170,15 +170,12 @@ public sealed class SessionHandlers
             stage: SessionResumeStage.RESPONSE,
             sessionToken: default,
             reason: reason,
-            flags: PacketFlags.SYSTEM | (tcp is not null ? PacketFlags.RELIABLE : PacketFlags.UNRELIABLE));
+            flags: PacketFlags.SYSTEM | PacketFlags.RELIABLE);
 
         try
         {
-            if (tcp is not null)
-            {
-                await tcp.SendAsync(ack)
-                         .ConfigureAwait(false);
-            }
+            await tcp.SendAsync(ack)
+                     .ConfigureAwait(false);
         }
         finally
         {


### PR DESCRIPTION
## Summary

<!-- Briefly describe the purpose of this PR and what it implements or fixes. -->

This pull request makes a targeted update to how session failure responses are sent in `SessionHandlers.cs`. The main change is to always use the `RELIABLE` flag when sending a failure response, regardless of whether the TCP transport is available.

**Session failure handling update:**

* Always sets the `PacketFlags.RELIABLE` flag (in addition to `SYSTEM`) when sending a `SessionResume` failure response, instead of conditionally using `RELIABLE` or `UNRELIABLE` based on the presence of a TCP connection.
* Refactors the code to assign `connection.TCP` to a local variable `tcp` for clarity and consistent usage.

---

## Type of Change

- [x] 🐛 Bug fix
- [ ] 🚀 Feature / enhancement
- [ ] ⚡ Performance improvement
- [ ] 🔧 Refactor
- [ ] 📚 Documentation update
- [ ] 🔒 Security fix
- [ ] 🧪 Tests

---

## Checklist

- [x] Code follows project style guidelines (`.editorconfig`).
- [x] Tests cover all changes.
- [x] All tests pass locally (`dotnet test`).
- [x] Documentation updated (if applicable).
- [x] Self-reviewed my own code.
- [x] No merge conflicts with `master`.
