### PR TITLE
fix(network): session token overwrite

### DIFF
--- a/src/Nalix.Network/Sessions/InMemorySessionStore.cs
+++ b/src/Nalix.Network/Sessions/InMemorySessionStore.cs
@@ -88,8 +88,34 @@ public sealed class InMemorySessionStore : SessionStoreBase, IDisposable
         ArgumentNullException.ThrowIfNull(entry);
         cancellationToken.ThrowIfCancellationRequested();
 
-        _store[entry.Snapshot.SessionToken] = entry;
-        return ValueTask.CompletedTask;
+        UInt56 token = entry.Snapshot.SessionToken;
+
+        while (true)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            if (_store.TryAdd(token, entry))
+            {
+                return ValueTask.CompletedTask;
+            }
+
+            if (!_store.TryGetValue(token, out SessionEntry? current))
+            {
+                continue;
+            }
+
+            // Already stored this exact reference for the token.
+            if (ReferenceEquals(current, entry))
+            {
+                return ValueTask.CompletedTask;
+            }
+
+            if (_store.TryUpdate(token, entry, current))
+            {
+                current.Return();
+                return ValueTask.CompletedTask;
+            }
+        }
     }
 
     /// <inheritdoc />

--- a/tests/Nalix.Network.Test/ConnectionHubSessionTests.cs
+++ b/tests/Nalix.Network.Test/ConnectionHubSessionTests.cs
@@ -143,6 +143,43 @@ public sealed class ConnectionHubSessionTests
         _ = updated.Snapshot.Attributes.Should().ContainKey("custom").WhoseValue.Should().Be("data");
     }
 
+    [Fact]
+    public async Task StoreAsync_WhenTokenIsOverwritten_ReturnsPreviousEntry()
+    {
+        using ConnectionHub hub = new();
+        using ConnectedSocketScope scope = await ConnectedSocketScope.CreateAsync();
+        using Connection connection = new(scope.ServerSocket);
+
+        connection.Secret = new Common.Primitives.Bytes32(System.Security.Cryptography.RandomNumberGenerator.GetBytes(32));
+        connection.Attributes["marker"] = "old";
+
+        SessionEntry original = hub.SessionStore.CreateSession(connection);
+        await hub.SessionStore.StoreAsync(original);
+
+        SessionSnapshot replacementSnapshot = new()
+        {
+            SessionToken = original.Snapshot.SessionToken,
+            CreatedAtUnixMilliseconds = original.Snapshot.CreatedAtUnixMilliseconds,
+            ExpiresAtUnixMilliseconds = original.Snapshot.ExpiresAtUnixMilliseconds,
+            Secret = new Common.Primitives.Bytes32(System.Security.Cryptography.RandomNumberGenerator.GetBytes(32)),
+            Algorithm = original.Snapshot.Algorithm,
+            Level = original.Snapshot.Level,
+            Attributes = ObjectMap<string, object>.Rent()
+        };
+        replacementSnapshot.Attributes!["marker"] = "new";
+
+        SessionEntry replacement = new(replacementSnapshot, original.ConnectionId);
+        await hub.SessionStore.StoreAsync(replacement);
+
+        _ = original.Snapshot.Secret.Should().Be(Common.Primitives.Bytes32.Zero);
+        _ = original.Snapshot.Attributes.Should().BeNull();
+
+        SessionEntry? stored = await hub.SessionStore.RetrieveAsync(original.Snapshot.SessionToken);
+        _ = stored.Should().BeSameAs(replacement);
+
+        await hub.SessionStore.RemoveAsync(original.Snapshot.SessionToken);
+    }
+
     private static void SyncSession(IConnection connection, SessionEntry session)
     {
         SessionSnapshot old = session.Snapshot;


### PR DESCRIPTION
## Summary

<!-- Briefly describe the purpose of this PR and what it implements or fixes. -->

This pull request improves the concurrency handling and correctness of session storage in the in-memory session store, and adds a new test to verify correct behavior when overwriting sessions with the same token.

**Improvements to session storage logic:**

* Updated the `StoreAsync` method in `InMemorySessionStore` to use a thread-safe loop with `TryAdd` and `TryUpdate` for storing sessions, ensuring that overwriting an existing session entry for the same token properly disposes of the previous entry and handles concurrent updates safely.

**Testing and validation:**

* Added a new test `StoreAsync_WhenTokenIsOverwritten_ReturnsPreviousEntry` in `ConnectionHubSessionTests.cs` to verify that when a session entry is overwritten for the same token, the previous entry is properly cleaned up and the new entry is retrievable.

---

## Type of Change

- [x] 🐛 Bug fix
- [ ] 🚀 Feature / enhancement
- [ ] ⚡ Performance improvement
- [ ] 🔧 Refactor
- [ ] 📚 Documentation update
- [x] 🔒 Security fix
- [x] 🧪 Tests