### PR TITLE
fix: network session management

### DIFF
--- a/src/Nalix.Common/Networking/INetworkEndpoint.cs
+++ b/src/Nalix.Common/Networking/INetworkEndpoint.cs
@@ -29,7 +29,8 @@ public interface INetworkEndpoint
     /// </summary>
     /// <value>
     /// A normalized IPv4 or IPv6 address string that does not include
-    /// port information.
+    /// port information. For authentication/pinning checks, compare this
+    /// value together with <see cref="Port"/> when <see cref="HasPort"/> is true.
     /// </value>
     /// <remarks>
     /// The returned value must be stable and suitable for equality

--- a/src/Nalix.Framework/Security/HandshakeX25519.cs
+++ b/src/Nalix.Framework/Security/HandshakeX25519.cs
@@ -5,6 +5,7 @@ using System;
 using System.Buffers.Binary;
 using Nalix.Common.Primitives;
 using Nalix.Framework.Security.Hashing;
+using Nalix.Framework.Security.Primitives;
 
 namespace Nalix.Framework.Security;
 
@@ -60,6 +61,11 @@ public static class HandshakeX25519
     /// <summary>
     /// Composes the initial transcript buffer from public keys and nonces to compute the transcript hash.
     /// </summary>
+    /// <remarks>
+    /// This API is kept for compatibility and returns raw transcript bytes.
+    /// Callers should wipe the returned buffer with
+    /// <see cref="Nalix.Framework.Security.Primitives.MemorySecurity.ZeroMemory(byte[])"/> after hashing.
+    /// </remarks>
     public static byte[] ComposeTranscriptBuffer(Bytes32 clientPublicKey, Bytes32 clientNonce, Bytes32 serverPublicKey, Bytes32 serverNonce)
     {
         int total = (sizeof(int) * 4)
@@ -72,12 +78,37 @@ public static class HandshakeX25519
         Span<byte> destination = buffer;
         int offset = 0;
 
-        offset = WriteSegment(destination, offset, clientPublicKey.AsSpan());
-        offset = WriteSegment(destination, offset, clientNonce.AsSpan());
-        offset = WriteSegment(destination, offset, serverPublicKey.AsSpan());
-        _ = WriteSegment(destination, offset, serverNonce.AsSpan());
+        try
+        {
+            offset = WriteSegment(destination, offset, clientPublicKey.AsSpan());
+            offset = WriteSegment(destination, offset, clientNonce.AsSpan());
+            offset = WriteSegment(destination, offset, serverPublicKey.AsSpan());
+            _ = WriteSegment(destination, offset, serverNonce.AsSpan());
 
-        return buffer;
+            return buffer;
+        }
+        catch
+        {
+            MemorySecurity.ZeroMemory(buffer);
+            throw;
+        }
+    }
+
+    /// <summary>
+    /// Computes the handshake transcript hash from public keys and nonces,
+    /// and securely clears the temporary heap buffer after hashing.
+    /// </summary>
+    public static Bytes32 ComputeTranscriptHash(Bytes32 clientPublicKey, Bytes32 clientNonce, Bytes32 serverPublicKey, Bytes32 serverNonce)
+    {
+        byte[] buffer = ComposeTranscriptBuffer(clientPublicKey, clientNonce, serverPublicKey, serverNonce);
+        try
+        {
+            return Keccak256.HashDataToFixed(buffer);
+        }
+        finally
+        {
+            MemorySecurity.ZeroMemory(buffer);
+        }
     }
 
     #endregion Public Methods
@@ -92,11 +123,18 @@ public static class HandshakeX25519
         Span<byte> destination = buffer;
         int offset = 0;
 
-        offset = WriteSegment(destination, offset, label);
-        offset = WriteSegment(destination, offset, segment0);
-        _ = WriteSegment(destination, offset, segment1);
+        try
+        {
+            offset = WriteSegment(destination, offset, label);
+            offset = WriteSegment(destination, offset, segment0);
+            _ = WriteSegment(destination, offset, segment1);
 
-        return Keccak256.HashDataToFixed(buffer);
+            return Keccak256.HashDataToFixed(buffer);
+        }
+        finally
+        {
+            MemorySecurity.ZeroMemory(buffer);
+        }
     }
 
     private static Bytes32 ComputeDigest(ReadOnlySpan<byte> label, ReadOnlySpan<byte> segment0, ReadOnlySpan<byte> segment1, ReadOnlySpan<byte> segment2, ReadOnlySpan<byte> segment3)
@@ -112,13 +150,20 @@ public static class HandshakeX25519
         Span<byte> destination = buffer;
         int offset = 0;
 
-        offset = WriteSegment(destination, offset, label);
-        offset = WriteSegment(destination, offset, segment0);
-        offset = WriteSegment(destination, offset, segment1);
-        offset = WriteSegment(destination, offset, segment2);
-        _ = WriteSegment(destination, offset, segment3);
+        try
+        {
+            offset = WriteSegment(destination, offset, label);
+            offset = WriteSegment(destination, offset, segment0);
+            offset = WriteSegment(destination, offset, segment1);
+            offset = WriteSegment(destination, offset, segment2);
+            _ = WriteSegment(destination, offset, segment3);
 
-        return Keccak256.HashDataToFixed(buffer);
+            return Keccak256.HashDataToFixed(buffer);
+        }
+        finally
+        {
+            MemorySecurity.ZeroMemory(buffer);
+        }
     }
 
     private static int WriteSegment(Span<byte> destination, int offset, ReadOnlySpan<byte> value)

--- a/src/Nalix.Network/Connections/Connection.Hub.cs
+++ b/src/Nalix.Network/Connections/Connection.Hub.cs
@@ -1244,31 +1244,64 @@ public sealed class ConnectionHub : IConnectionHub
         {
             SessionEntry session = _sessionStore.CreateSession(connection);
 
-            // Fire-and-forget storage to avoid blocking the critical unregistration path.
-            // Capture metadata early to avoid potential race conditions if the connection is recycled.
             ILogger? logger = _logger;
             ISnowflake id = connection.ID;
+            int attributeCount = connection.Attributes.Count;
 
-            _ = Task.Run(async () =>
+            ValueTask storeTask;
+            try
             {
-                try
-                {
-                    await _sessionStore.StoreAsync(session).ConfigureAwait(false);
-                }
-                catch (Exception ex)
-                {
-                    logger?.Error(ex, $"[NW.{nameof(ConnectionHub)}] auto-persist-error id={id}");
-                }
-            });
+                storeTask = _sessionStore.StoreAsync(session);
+            }
+            catch (Exception ex)
+            {
+                session.Return();
+                logger?.Error(ex, $"[NW.{nameof(ConnectionHub)}] auto-persist-error id={id}");
+                return;
+            }
 
-            if (_logger?.IsEnabled(LogLevel.Debug) == true)
+            if (storeTask.IsCompletedSuccessfully)
             {
-                _logger.Debug($"[NW.{nameof(ConnectionHub)}] auto-persist queued id={connection.ID} attributes={connection.Attributes.Count}");
+                if (logger?.IsEnabled(LogLevel.Debug) == true)
+                {
+                    logger.Debug($"[NW.{nameof(ConnectionHub)}] auto-persist done id={id} attributes={attributeCount}");
+                }
+
+                return;
+            }
+
+            // Keep unregistration non-blocking, but ensure cleanup if persistence fails.
+            _ = PersistSessionAsync(storeTask, session, logger, id);
+
+            if (logger?.IsEnabled(LogLevel.Debug) == true)
+            {
+                logger.Debug($"[NW.{nameof(ConnectionHub)}] auto-persist queued id={id} attributes={attributeCount}");
             }
         }
         catch (Exception ex)
         {
             _logger?.Error(ex, $"[NW.{nameof(ConnectionHub)}] auto-persist-prepare-error id={connection.ID}");
+        }
+    }
+
+    private static async Task PersistSessionAsync(ValueTask storeTask, SessionEntry session, ILogger? logger, ISnowflake id)
+    {
+        bool stored = false;
+        try
+        {
+            await storeTask.ConfigureAwait(false);
+            stored = true;
+        }
+        catch (Exception ex)
+        {
+            logger?.Error(ex, $"[NW.{nameof(ConnectionHub)}] auto-persist-error id={id}");
+        }
+        finally
+        {
+            if (!stored)
+            {
+                session.Return();
+            }
         }
     }
 

--- a/src/Nalix.Network/Listeners/UdpListener/UdpListener.Receive.cs
+++ b/src/Nalix.Network/Listeners/UdpListener/UdpListener.Receive.cs
@@ -81,8 +81,28 @@ public abstract partial class UdpListenerBase
             s_logger?.Error($"[NW.{nameof(UdpListenerBase)}:{nameof(StartReceive)}] recv-error port={_port}", ex);
 
             // Brief delay to prevent tight error loops on synchronous failure.
-            _ = Task.Delay(50, _cancellationToken).ContinueWith(_ => this.StartReceive(args), TaskScheduler.Default);
+            _ = this.RetryStartReceiveAsync(args, _cancellationToken);
         }
+    }
+
+    [DebuggerStepThrough]
+    private async Task RetryStartReceiveAsync(PooledUdpReceiveEventArgs args, CancellationToken cancellationToken)
+    {
+        try
+        {
+            await Task.Delay(50, cancellationToken).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            return;
+        }
+
+        if (Volatile.Read(ref _isDisposed) != 0 || _socket is null || cancellationToken.IsCancellationRequested)
+        {
+            return;
+        }
+
+        this.StartReceive(args);
     }
 
     [DebuggerStepThrough]
@@ -203,9 +223,10 @@ public abstract partial class UdpListenerBase
             return;
         }
 
-        // --- 3. IP pinning gate (SEC-30) ---
+        // --- 3. Endpoint pinning gate (SEC-30) ---
         if (connection.NetworkEndpoint is null ||
-            !string.Equals(connection.NetworkEndpoint.Address, ((IPEndPoint)remoteEndPoint).Address.ToString(), StringComparison.Ordinal))
+            remoteEndPoint is not IPEndPoint remoteIpEndPoint ||
+            !this.IsPinnedEndpointMatch(connection.NetworkEndpoint, remoteIpEndPoint))
         {
             _ = Interlocked.Increment(ref _dropUnauth);
             lease.Dispose();
@@ -272,6 +293,28 @@ public abstract partial class UdpListenerBase
             // Dispose the original wrapping lease; the inner buffer was either transferred or rejected.
             lease.Dispose();
         }
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private bool IsPinnedEndpointMatch(INetworkEndpoint pinnedEndPoint, IPEndPoint remoteEndPoint)
+    {
+        IPAddress remoteAddress = remoteEndPoint.Address;
+        if (remoteAddress.IsIPv4MappedToIPv6)
+        {
+            remoteAddress = remoteAddress.MapToIPv4();
+        }
+
+        if (!string.Equals(pinnedEndPoint.Address, remoteAddress.ToString(), StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        if (pinnedEndPoint.HasPort && pinnedEndPoint.Port != remoteEndPoint.Port)
+        {
+            return false;
+        }
+
+        return true;
     }
 
     /// <summary>

--- a/src/Nalix.Runtime/Handlers/HandshakeHandlers.cs
+++ b/src/Nalix.Runtime/Handlers/HandshakeHandlers.cs
@@ -36,7 +36,7 @@ public sealed class HandshakeHandlers
     private static IConnectionHub? Hub => InstanceManager.Instance.GetExistingInstance<IConnectionHub>();
 
     private static Bytes32 s_certificate = Bytes32.Zero;
-    private static bool s_isInitialized;
+    private static int s_isInitialized;
     private static readonly Lock s_initLock = new();
 
     #endregion Fields
@@ -51,20 +51,20 @@ public sealed class HandshakeHandlers
     /// </remarks>
     public static void Initialize()
     {
-        if (s_isInitialized)
+        if (Volatile.Read(ref s_isInitialized) != 0)
         {
             return;
         }
 
         lock (s_initLock)
         {
-            if (s_isInitialized)
+            if (Volatile.Read(ref s_isInitialized) != 0)
             {
                 return;
             }
 
             LOAD_CERTIFICATE(Path.Combine(Directories.ConfigurationDirectory, "certificate.private"));
-            s_isInitialized = true;
+            Volatile.Write(ref s_isInitialized, 1);
         }
     }
 
@@ -78,7 +78,7 @@ public sealed class HandshakeHandlers
         lock (s_initLock)
         {
             LOAD_CERTIFICATE(path);
-            s_isInitialized = true;
+            Volatile.Write(ref s_isInitialized, 1);
         }
     }
 
@@ -205,8 +205,8 @@ public sealed class HandshakeHandlers
 
     private static async ValueTask HandleClientHelloAsync(IConnection connection, Handshake packet)
     {
-        // BUG-75: Prevent re-entry during active handshake to mitigate CPU DoS
-        if (connection.Attributes.ContainsKey(ConnectionAttributes.HandshakeState))
+        // BUG-75: Atomically reserve handshake state to prevent re-entry races.
+        if (!TryAcquireHandshakeSlot(connection, out object claimToken))
         {
             await RejectHandshakeAsync(connection, ProtocolReason.STATE_VIOLATION).ConfigureAwait(false);
             return;
@@ -233,12 +233,11 @@ public sealed class HandshakeHandlers
 
         Bytes32 serverNonce = new(Csprng.GetBytes(Bytes32.Size));
 
-        Bytes32 transcriptHash = Handshake.ComputeTranscriptHash(
-            HandshakeX25519.ComposeTranscriptBuffer(
-                packet.PublicKey,
-                packet.Nonce,
-                serverKey.PublicKey,
-                serverNonce));
+        Bytes32 transcriptHash = HandshakeX25519.ComputeTranscriptHash(
+            packet.PublicKey,
+            packet.Nonce,
+            serverKey.PublicKey,
+            serverNonce);
 
         HandshakeContext state = new()
         {
@@ -251,7 +250,11 @@ public sealed class HandshakeHandlers
             SessionKey = HandshakeX25519.DeriveSessionKey(masterSecret, packet.Nonce, serverNonce, transcriptHash)
         };
 
-        connection.Attributes[ConnectionAttributes.HandshakeState] = state;
+        if (!TryPublishHandshakeState(connection, claimToken, state))
+        {
+            await RejectHandshakeAsync(connection, ProtocolReason.STATE_VIOLATION).ConfigureAwait(false);
+            return;
+        }
 
         using PacketLease<Handshake> lease = PacketPool<Handshake>.Rent();
         Handshake reply = lease.Value;
@@ -309,10 +312,7 @@ public sealed class HandshakeHandlers
 
     private static async ValueTask RejectHandshakeAsync(IConnection connection, ProtocolReason reason)
     {
-        if (TryGetState(connection, out HandshakeContext? state) && state is not null)
-        {
-            _ = connection.Attributes.Remove(ConnectionAttributes.HandshakeState);
-        }
+        _ = connection.Attributes.Remove(ConnectionAttributes.HandshakeState);
 
         try
         {
@@ -339,6 +339,27 @@ public sealed class HandshakeHandlers
 
         state = null;
         return false;
+    }
+
+    private static bool TryAcquireHandshakeSlot(IConnection connection, out object claimToken)
+    {
+        claimToken = new object();
+        connection.Attributes.Add(ConnectionAttributes.HandshakeState, claimToken);
+
+        return connection.Attributes.TryGetValue(ConnectionAttributes.HandshakeState, out object? current) &&
+               ReferenceEquals(current, claimToken);
+    }
+
+    private static bool TryPublishHandshakeState(IConnection connection, object claimToken, HandshakeContext state)
+    {
+        if (!connection.Attributes.TryGetValue(ConnectionAttributes.HandshakeState, out object? current) ||
+            !ReferenceEquals(current, claimToken))
+        {
+            return false;
+        }
+
+        connection.Attributes[ConnectionAttributes.HandshakeState] = state;
+        return true;
     }
 
     #endregion Private Methods

--- a/src/Nalix.SDK/Transport/Extensions/HandshakeExtensions.cs
+++ b/src/Nalix.SDK/Transport/Extensions/HandshakeExtensions.cs
@@ -96,8 +96,11 @@ public static class HandshakeExtensions
 
         Bytes32 masterSecret = HandshakeX25519.ComputeMasterSecret(sharedSecretEE, sharedSecretSE);
 
-        Bytes32 transcriptHash = Handshake.ComputeTranscriptHash(
-            HandshakeX25519.ComposeTranscriptBuffer(clientKey.PublicKey, clientNonce, serverHello.PublicKey, serverHello.Nonce));
+        Bytes32 transcriptHash = HandshakeX25519.ComputeTranscriptHash(
+            clientKey.PublicKey,
+            clientNonce,
+            serverHello.PublicKey,
+            serverHello.Nonce);
 
         Bytes32 expectedProof = HandshakeX25519.ComputeServerProof(masterSecret, transcriptHash);
         if (serverHello.Proof != expectedProof)

--- a/tests/Nalix.Network.Test/ConnectionHubTests.cs
+++ b/tests/Nalix.Network.Test/ConnectionHubTests.cs
@@ -2,10 +2,15 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Net;
 using System.Net.Sockets;
+using System.Security.Cryptography;
+using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Nalix.Common.Networking;
+using Nalix.Common.Networking.Sessions;
+using Nalix.Common.Primitives;
 using Nalix.Network.Connections;
+using Nalix.Network.Sessions;
 using Xunit;
 
 namespace Nalix.Network.Tests;
@@ -45,6 +50,30 @@ public sealed class ConnectionHubTests
         hub.GetConnection(connection.ID).Should().BeNull();
     }
 
+    [Fact]
+    public async Task UnregisterConnection_WhenSessionStoreFails_ReclaimsSessionSnapshot()
+    {
+        using FailingSessionStore failingStore = new();
+        using ConnectionHub hub = new(failingStore);
+        using ConnectedSocketScope scope = await ConnectedSocketScope.CreateAsync();
+        using Connection connection = new(scope.ServerSocket);
+
+        connection.Secret = new Bytes32(RandomNumberGenerator.GetBytes(Bytes32.Size));
+        connection.Attributes[ConnectionAttributes.HandshakeEstablished] = true;
+        connection.Attributes["attr-1"] = 1;
+        connection.Attributes["attr-2"] = 2;
+        connection.Attributes["attr-3"] = 3;
+        connection.Attributes["attr-4"] = 4;
+        connection.Attributes["attr-5"] = 5;
+
+        hub.RegisterConnection(connection);
+        hub.UnregisterConnection(connection);
+
+        SessionEntry attempted = await failingStore.WaitForStoreAttemptAsync(TimeSpan.FromSeconds(3));
+        attempted.Snapshot.Secret.Should().Be(Bytes32.Zero);
+        attempted.Snapshot.Attributes.Should().BeNull();
+    }
+
     private sealed class ConnectedSocketScope : IDisposable
     {
         private ConnectedSocketScope(Socket listenerSocket, Socket clientSocket, Socket serverSocket)
@@ -81,6 +110,53 @@ public sealed class ConnectionHubTests
             try { ClientSocket.Dispose(); } catch { }
             try { ServerSocket.Dispose(); } catch { }
             try { ListenerSocket.Dispose(); } catch { }
+        }
+    }
+
+    private sealed class FailingSessionStore : SessionStoreBase, IDisposable
+    {
+        private readonly TaskCompletionSource<SessionEntry> _storeAttempt =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public async Task<SessionEntry> WaitForStoreAttemptAsync(TimeSpan timeout)
+        {
+            using CancellationTokenSource cts = new(timeout);
+            Task completed = await Task.WhenAny(_storeAttempt.Task, Task.Delay(Timeout.InfiniteTimeSpan, cts.Token));
+            if (completed != _storeAttempt.Task)
+            {
+                throw new TimeoutException("Session store was not invoked in time.");
+            }
+
+            return await _storeAttempt.Task;
+        }
+
+        public override ValueTask StoreAsync(SessionEntry entry, CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            _storeAttempt.TrySetResult(entry);
+            throw new InvalidOperationException("Simulated session-store failure.");
+        }
+
+        public override ValueTask RemoveAsync(UInt56 sessionToken, CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return ValueTask.CompletedTask;
+        }
+
+        public override ValueTask<SessionEntry?> RetrieveAsync(UInt56 sessionToken, CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return ValueTask.FromResult<SessionEntry?>(null);
+        }
+
+        public override ValueTask<SessionEntry?> ConsumeAsync(UInt56 sessionToken, CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return ValueTask.FromResult<SessionEntry?>(null);
+        }
+
+        public void Dispose()
+        {
         }
     }
 }


### PR DESCRIPTION
## Summary

<!-- Briefly describe the purpose of this PR and what it implements or fixes. -->

This pull request introduces several important improvements across networking, security, and reliability in the codebase. The main focus is on enhancing endpoint pinning for UDP connections, improving cryptographic memory hygiene, making handshake logic more robust against race conditions, and improving session persistence error handling. Additionally, new tests are added to verify session cleanup on storage failures.

**Security and Memory Hygiene Improvements:**

- Added secure zeroing of sensitive buffers in `HandshakeX25519` cryptographic operations to prevent leaking sensitive data, and introduced a new `ComputeTranscriptHash` method that ensures memory is wiped after use. [[1]](diffhunk://#diff-e6f63b25f763e0598d10aad7d5f73e6d67c64d92daa6ede9d5b45f57f9322dc0R8) [[2]](diffhunk://#diff-e6f63b25f763e0598d10aad7d5f73e6d67c64d92daa6ede9d5b45f57f9322dc0R64-R68) [[3]](diffhunk://#diff-e6f63b25f763e0598d10aad7d5f73e6d67c64d92daa6ede9d5b45f57f9322dc0R81-R112) [[4]](diffhunk://#diff-e6f63b25f763e0598d10aad7d5f73e6d67c64d92daa6ede9d5b45f57f9322dc0R126-R138) [[5]](diffhunk://#diff-e6f63b25f763e0598d10aad7d5f73e6d67c64d92daa6ede9d5b45f57f9322dc0R153-R154) [[6]](diffhunk://#diff-e6f63b25f763e0598d10aad7d5f73e6d67c64d92daa6ede9d5b45f57f9322dc0R163-R167) [[7]](diffhunk://#diff-d6ae86327b53f1ef65c1b0c61dc97d3845b992b3ce0a59a5384093fa8983024bL99-R103)

**Networking and Endpoint Pinning:**

- Improved UDP endpoint pinning to compare both address and port, using a new `IsPinnedEndpointMatch` method, and updated documentation to clarify port comparison for authentication/pinning checks. [[1]](diffhunk://#diff-c8a8ed212e8f2576d29546ef744af398fdcf340e9d6e2dc58c836940ee844e42L32-R33) [[2]](diffhunk://#diff-f82633fc5da1d737e3a07e95a1bc9645518d64f7b16ac077a7de94e8ea1f4bf8L206-R229) [[3]](diffhunk://#diff-f82633fc5da1d737e3a07e95a1bc9645518d64f7b16ac077a7de94e8ea1f4bf8R298-R319)

**Reliability and Error Handling:**

- Refactored UDP receive retry logic to use an async method (`RetryStartReceiveAsync`) for more robust handling of cancellation and disposal scenarios.
- Improved session persistence in `ConnectionHub` to ensure session snapshots are reclaimed if storage fails, and made persistence non-blocking while adding detailed logging. [[1]](diffhunk://#diff-b50c7e7c77ee5ac9b19930b0e71687472c333e10dc87135a60258463d1a8f8dcL1247-R1278) [[2]](diffhunk://#diff-b50c7e7c77ee5ac9b19930b0e71687472c333e10dc87135a60258463d1a8f8dcR1287-R1307)

**Handshake and Concurrency Robustness:**

- Hardened handshake logic against races and re-entrancy by introducing atomic claim/publish of handshake state, replacing simple dictionary checks. [[1]](diffhunk://#diff-9690dbadfdf8caacca86ac328e3805f159af8a7778ce8f0fba13a4ea0b1e87acL39-R39) [[2]](diffhunk://#diff-9690dbadfdf8caacca86ac328e3805f159af8a7778ce8f0fba13a4ea0b1e87acL54-R67) [[3]](diffhunk://#diff-9690dbadfdf8caacca86ac328e3805f159af8a7778ce8f0fba13a4ea0b1e87acL81-R81) [[4]](diffhunk://#diff-9690dbadfdf8caacca86ac328e3805f159af8a7778ce8f0fba13a4ea0b1e87acL208-R209) [[5]](diffhunk://#diff-9690dbadfdf8caacca86ac328e3805f159af8a7778ce8f0fba13a4ea0b1e87acL236-R240) [[6]](diffhunk://#diff-9690dbadfdf8caacca86ac328e3805f159af8a7778ce8f0fba13a4ea0b1e87acL254-R257) [[7]](diffhunk://#diff-9690dbadfdf8caacca86ac328e3805f159af8a7778ce8f0fba13a4ea0b1e87acL311-L315) [[8]](diffhunk://#diff-9690dbadfdf8caacca86ac328e3805f159af8a7778ce8f0fba13a4ea0b1e87acR344-R364)

**Testing:**

- Added a test to ensure session snapshots are properly reclaimed if session store persistence fails during connection unregistration. [[1]](diffhunk://#diff-7914f3d3a6994d536aee0e8e57035d8dcb9480c7035fdad8ea74ef5b50637fa0R5-R13) [[2]](diffhunk://#diff-7914f3d3a6994d536aee0e8e57035d8dcb9480c7035fdad8ea74ef5b50637fa0R53-R76)

---

## Type of Change

- [x] 🐛 Bug fix
- [ ] 🚀 Feature / enhancement
- [ ] ⚡ Performance improvement
- [x] 🔧 Refactor
- [ ] 📚 Documentation update
- [ ] 🔒 Security fix
- [ ] 🧪 Tests